### PR TITLE
Fixed undefined error in NoteHelpers moveNote()

### DIFF
--- a/jgclark.NoteHelpers/plugin.json
+++ b/jgclark.NoteHelpers/plugin.json
@@ -6,7 +6,7 @@
   "plugin.icon": "",
   "plugin.author": "Jonathan Clark & Eduard Metzger",
   "plugin.url": "https://github.com/NotePlan/plugins/tree/main/jgclark.NoteHelpers/",
-  "plugin.version": "0.9.1",
+  "plugin.version": "0.9.2",
   "plugin.changelog": "See plugin README.md",
   "plugin.dependencies": [],
   "plugin.script": "script.js",

--- a/jgclark.NoteHelpers/src/noteHelpers.js
+++ b/jgclark.NoteHelpers/src/noteHelpers.js
@@ -5,17 +5,18 @@
 // v0.9.0, 29.6.2021
 //--------------------------------------------------------------------------------------------------------------------
 
-import { projectNotesSortedByChanged, printNote } from '../../helperFunctions'
+import { projectNotesSortedByChanged, printNote, chooseFolder } from '../../helperFunctions'
 
 //-----------------------------------------------------------------
 // Command from Eduard to move a note to a different folder
-export function moveNote(selectedFolder: string) {
+export async function moveNote() {
   const { title, filename } = Editor
   if (title == null || filename == null) {
     // No note open, so don't do anything.
     console.log('moveNote: warning: No note open.')
     return
   }
+  const selectedFolder = await chooseFolder("Select a folder for '" + title + "'")
   console.log(`move ${title} (filename = ${filename}) to ${selectedFolder}`)
 
   const newFilename = DataStore.moveNote(filename, selectedFolder)


### PR DESCRIPTION
I was getting an "undefined" error when trying to move a note via `/mn`. The variable `selectedFolder` was set as a parameter for `moveNote()`, but no value is passed. This was moving the note to a new untitled folder.

The update below uses the [`chooseFolder()`](https://github.com/NotePlan/plugins/blob/5567532000a5bffd8381c67f1dd9887743c088dd/helperFunctions.js#L379) function to interactively select the destination folder.