### PR TITLE
fix: improve handling of plugins path

### DIFF
--- a/scripts/shared.js
+++ b/scripts/shared.js
@@ -104,7 +104,7 @@ async function getCopyTargetPath(dirents) {
   )
   if (hasPluginPathFile) {
     const path = await fs.readFile(pluginPathFile, 'utf8')
-    console.log('path:', path)
+    // Cleanup any newlines from the path value
     return path.replace(/\r?\n|\r/g, '')
   }
 

--- a/scripts/shared.js
+++ b/scripts/shared.js
@@ -104,7 +104,8 @@ async function getCopyTargetPath(dirents) {
   )
   if (hasPluginPathFile) {
     const path = await fs.readFile(pluginPathFile, 'utf8')
-    return path
+    console.log('path:', path)
+    return path.replace(/\r?\n|\r/g, '')
   }
 
   const { shouldCopy } = await inquirer.prompt([
@@ -129,7 +130,7 @@ async function getCopyTargetPath(dirents) {
         type: 'input',
         name: 'inputPath',
         default: `/Users/${username}/Library/Containers/co.noteplan.NotePlan3/Data/Library/Application Support/co.noteplan.NotePlan3/Plugins`,
-        message: `Enter the absolute path to the noteplan Plugins folder below. (Should start with "/" end with "/Plugins" -- No trailing slash and no escapes (backslashes) in the path. On a Mac, it would be something like the suggestion below\n[type path or enter to accept this suggestion.]\n>>`,
+        message: `Enter the absolute path to the noteplan Plugins folder below. (Should start with "/" end with "/Plugins" -- No trailing slash and no escapes (backslashes, e.g. avoid "\\ ") in the path. On a Mac, it would be something like the suggestion below\n[type path or enter to accept this suggestion.]\n>>`,
       },
     ])
     pluginPath = inputPath


### PR DESCRIPTION
Remove any trailing or leading new line characters from the path that has been read from the `.pluginpath`-file to avoid common issue were editors (e.g. Visual Studio Code) likes to save a empty new line at the end of source files