### PR TITLE
Changing `---` in Templates from a requirement to a nice-to-have

### DIFF
--- a/nmn.Templates/changelog.md
+++ b/nmn.Templates/changelog.md
@@ -2,6 +2,8 @@ See Template Plugin [README](https://github.com/NotePlan/plugins/blob/main/nmn.T
 
 # What's Changed in this Plugin?
 
+### 0.10.3 Changing `---` from a requirement to a nice-to-have
+
 ### 0.10.2 Fixed "/" bug (again) in /qtn (thanks @jgclark!)
 
 ### 0.10.1 Fixed "/" bug in /qtn (thanks @jgclark!)

--- a/nmn.Templates/plugin.json
+++ b/nmn.Templates/plugin.json
@@ -7,7 +7,7 @@
   "plugin.icon": "",
   "plugin.author": "Naman Goel & Jonathan Clark",
 	"plugin.url": "https://github.com/NotePlan/plugins/tree/main/nmn.Templates/",
-  "plugin.version": "0.10.2",
+  "plugin.version": "0.10.3",
   "plugin.dependencies": [ ],
   "plugin.script": "script.js",
   "plugin.isRemote": "false",

--- a/nmn.Templates/src/index.js
+++ b/nmn.Templates/src/index.js
@@ -31,7 +31,15 @@ async function getProcessedTemplate(templateTitle: string): Promise<string> {
     return '<template was empty>'
   }
 
-  templateContent = templateContent.split('\n---\n').slice(1).join('\n---\n')
+  const sections = templateContent.split('\n---\n')
+  if (sections.length < 2) {
+    console.log(
+      `\twarning: template '${templateTitle}' is missing horizontal rule "---". Will try to continue without it.`,
+    )
+    templateContent = templateContent.split('\n').slice(1).join('\n') // remove title line
+  } else {
+    templateContent = sections.slice(1).join('\n---\n')
+  }
 
   // Read all _configuration settings
   const config = (await getStructuredConfiguration()) ?? {}
@@ -98,7 +106,17 @@ export async function applyTemplate(newNote?: [string, string, string]) {
   if (templateContent == null) {
     return
   }
-  templateContent = templateContent.split('\n---\n').slice(1).join('\n---\n')
+  const sections = templateContent.split('\n---\n')
+  if (sections.length < 2) {
+    console.log(
+      `\twarning: template '${String(
+        templateName,
+      )}' is missing horizontal rule "---". Will try to continue without it.`,
+    )
+    templateContent = templateContent.split('\n').slice(1).join('\n') // remove title line
+  } else {
+    templateContent = sections.slice(1).join('\n---\n')
+  }
 
   const config = (await getStructuredConfiguration()) ?? {}
 


### PR DESCRIPTION
@jgclark @nmn The initial work on Templates was before my time, but I see the hard requirement for a horizontal rule. The first time I created a template, I forgot the `---` and didn't understand why it didn't work (until I re-read the README). Now we've heard from at least 2 users who have been tripped up by it. I am suggesting in this PR that we make the <HR> a nice-to-have rather than a hard requirement. If you have it, great. If not, we'll just use the whole note (other than the title). Unless there's some reason the <HR> needs to be a hard requirement? (in which case we should add better error reporting). Thoughts?