### PR TITLE
Fix: /todayStart wasn't running if you didn't have a calendar day open

### DIFF
--- a/jgclark.DailyJournal/CHANGELOG.md
+++ b/jgclark.DailyJournal/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+
+### v0.8.2, 7.9.2021
+- fix: fixed an error in /todayStart that kept it from running if the note wasn't open
+
 ### v0.8.1, 31.8.2021
 - under-the-hood changes responding to underlying framework changes
 

--- a/jgclark.DailyJournal/plugin.json
+++ b/jgclark.DailyJournal/plugin.json
@@ -7,7 +7,7 @@
   "plugin.icon": "",
   "plugin.author": "Jonathan Clark",
   "plugin.url": "https://github.com/NotePlan/plugins/blob/main/jgclark.DailyJournal/README.md",
-  "plugin.version": "0.8.1",
+  "plugin.version": "0.8.2",
   "plugin.dependencies": [],
   "plugin.script": "script.js",
   "plugin.isRemote": "false",

--- a/jgclark.DailyJournal/src/journal.js
+++ b/jgclark.DailyJournal/src/journal.js
@@ -49,10 +49,6 @@ export async function todayStart() {
 // Start the currently open daily note with the user's Daily Note Template
 export async function dayStart(today: boolean = false) {
   console.log(`\ndayStart:`)
-  if (Editor.note == null || Editor.type !== 'Calendar') {
-    await showMessage('Please run again with a calendar note open.')
-    return
-  }
   if (today) {
     // open today's date in the main window, and read content
     await Editor.openNoteByDate(new Date(), false)
@@ -60,6 +56,10 @@ export async function dayStart(today: boolean = false) {
     console.log(`Opened: ${displayTitle(Editor.note)}`)
   } else {
     // apply daily template in the currently open daily note
+    if (Editor.note == null || Editor.type !== 'Calendar') {
+      await showMessage('Please run again with a calendar note open.')
+      return
+    }
     await applyNamedTemplate(pref_templateTitle)
   }
 }
@@ -77,14 +77,15 @@ export async function dayReview(): Promise<void> {
   const journalConfig = await getOrMakeConfigurationSection(
     'dailyJournal',
     DEFAULT_JOURNAL_OPTIONS,
-    MINIMUM_JOURNAL_OPTIONS
+    MINIMUM_JOURNAL_OPTIONS,
   )
   // console.log(JSON.stringify(journalConfig))
-  if (journalConfig == null || Object.keys(journalConfig).length === 0) { // this is how to check for empty object
+  if (journalConfig == null || Object.keys(journalConfig).length === 0) {
+    // this is how to check for empty object
     console.log("\tWarning: Cannot find suitable 'dailyJournal' settings in Templates/_configuration note. Stopping.")
     await showMessage(
       "Cannot find 'dailyJournal' settings in _configuration.",
-      "Yes, I'll check my _configuration settings."
+      "Yes, I'll check my _configuration settings.",
     )
     return
   }
@@ -105,7 +106,7 @@ export async function dayReview(): Promise<void> {
       '🥵 Sick',
       'Other',
     ].join(',')
-  
+
   pref_moodArray = pref_moods.split(',') // with a proper config system, this won't be needed
 
   const question = []

--- a/jgclark.DailyJournal/src/journal.js
+++ b/jgclark.DailyJournal/src/journal.js
@@ -60,8 +60,8 @@ export async function dayStart(today: boolean = false) {
       await showMessage('Please run again with a calendar note open.')
       return
     }
-    await applyNamedTemplate(pref_templateTitle)
   }
+  await applyNamedTemplate(pref_templateTitle)
 }
 
 //------------------------------------------------------------------


### PR DESCRIPTION
fix: fixed an error in /todayStart that kept it from running if the note wasn't open. It now opens it automatically.
Not sure how I missed this before, but fixed it. Bumped version so it could be released whenever you get a chance to look @jgclark 