### PR TITLE
Added requirements part

### DIFF
--- a/jgclark.DailyJournal/README.md
+++ b/jgclark.DailyJournal/README.md
@@ -8,6 +8,9 @@ This plugin provides two commands for daily journalling, including start-of-day 
 ## Changes
 Please see the [CHANGELOG](CHANGELOG.md).
 
+## Requirements
+This template requires prior installation of the [Templates plugin](https://github.com/NotePlan/plugins/tree/main/nmn.Templates/).
+
 ## Configuration
 ### /dayStart and /todayStart
 `/dayStart` and `/todayStart` use the `Daily Note Template` note found in the `Templates` folder. If this note has not been added, it should prompt you to create one.


### PR DESCRIPTION
Hi,

first of all: Kudos to this really cool plugin.

During setup it took me a while to figure out that the templates plugin must also be installed: I was searching for the Templates-folder and couldn't find it, either in NotePlan or anywhere in the File system. 

To make it more clear thant the Templates plugin is required and to save some time and confusion for future users, I suggest to explicit Requirements section in the readme. :)

Best regards
Andreas