### PR TITLE
fix: errors with optional parameters

### DIFF
--- a/jgclark.EventHelpers/src/eventsToNotes.js
+++ b/jgclark.EventHelpers/src/eventsToNotes.js
@@ -122,7 +122,7 @@ export async function getEventsForDay(
 
 //------------------------------------------------------------------------------
 // Return MD list of today's events
-export async function listDaysEvents(paramString?: string = ''): Promise<string> {
+export async function listDaysEvents(paramString: string = ''): Promise<string> {
   if (Editor.note == null || Editor.type !== 'Calendar') {
     await showMessage('Please run again with a calendar note open.')
     return ''

--- a/jgclark.Summaries/src/stats.js
+++ b/jgclark.Summaries/src/stats.js
@@ -403,6 +403,7 @@ export async function weeklyStats(): Promise<void> {
   )
 
   // For every week of interest ...
+  // m1well: these arrays are empty and never changed again?
   let allHCounts = []
   let allHTotals = []
   const hOutputArray = []
@@ -421,6 +422,7 @@ export async function weeklyStats(): Promise<void> {
   }
 
   // First process more complex 'SumTotals', calculating appropriately
+  // m1well: in this file a some errors - e.g. 'hSumTotals' and 'hCounts' is only defined in the for-loop ?
   for (const [key, value] of hSumTotals) {
     // .entries() implied
     const hashtagString = pref_showAsHashtagOrMention ? key : key.slice(1)
@@ -449,7 +451,7 @@ export async function weeklyStats(): Promise<void> {
 
   // Calc mentions stats (returns two maps)
   const mOutputArray = []
-  results = calcMentionStatsPeriod(fromDateStr, toDateStr)
+  const results = calcMentionStatsPeriod(fromDateStr, toDateStr)
   const mCounts = results?.[0]
   const mSumTotals = results?.[1]
   if (mCounts == null || mSumTotals == null) {

--- a/nmn.Templates/src/templateController.js
+++ b/nmn.Templates/src/templateController.js
@@ -74,7 +74,7 @@ type TagListType = {
  * @param {Function} tagFunction - the function to call (usually an import above)
  * @param {boolean} includeConfig - whether to include the config in that function call
  */
-function addTag(tagName: string, tagFunction: Function, includeConfig?: boolean = false) {
+function addTag(tagName: string, tagFunction: Function, includeConfig: boolean = false) {
   tagList.push({ tagName, tagFunction, includeConfig })
 }
 


### PR DESCRIPTION
i fixed two errors with optional parameters (I wrote about that in the 'plugin-dev' channel)

`func(paramString?: string = '')` - this is double optional

either one should do `func(paramString: string = '')` -> then if there is no parameter it is set to an empty string
or one should do `func(paramString?)` -> this is cleaner, BUT then you need nullchecks in the following code

so I decided to go with the first option, just to get rid of this errors.

also I commented something in the `stats.js` because my IDE throws a lot of errors there. 