### PR TITLE
refactor: eslint added unused imports plugin

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,7 +9,8 @@
   ],
   "plugins": [
     "import",
-    "flowtype"
+    "flowtype",
+    "unused-imports"
   ],
   "parser": "@babel/eslint-parser",
   "parserOptions": {
@@ -56,7 +57,9 @@
     "no-prototype-builtins": "off",
     "no-unused-vars": "off",
     "import/order": "error",
-    "no-useless-escape": "off"
+    "no-useless-escape": "off",
+    "unused-imports/no-unused-imports": "error",
+    "unused-imports/no-unused-vars": "off"
   },
   "env": {
     "node": true,

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-flowtype": "^5.7.2",
     "eslint-plugin-import": "^2.23.2",
+    "eslint-plugin-unused-imports": "^2.0.0",
     "flow-bin": "^0.151.0",
     "inquirer": "^8.1.0",
     "jest": "27.0.6",


### PR DESCRIPTION
just if you say it is ok - then merge ;)

I found so many unused imports, that I thought I add the plugin to ESLint - then one can find out easily if there are unused imports.
(by the way there are still some other ESLint errors...)