### PR TITLE
ignore jest coverage files and .idea

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ package-lock.json
 .vscode/
 .pluginsrc
 .idea/
+lcov*
+coverage/


### PR DESCRIPTION
Every time I create a new branch, it shows the Jest coverage files. I'd like to add them to the Repo .gitignore