### PR TITLE
eventhelpers eventlist show calendarname

### DIFF
--- a/jgclark.EventHelpers/CHANGELOG.md
+++ b/jgclark.EventHelpers/CHANGELOG.md
@@ -4,7 +4,12 @@ See [website README for more details](https://github.com/NotePlan/plugins/tree/m
 - tighten timeblock-finding regex if Eduard does
 - add further fields (e.g. location) if Eduard adds to the API
 
-## [0.7.0] - 2021-19-11
+## [0.8.0] - 2021-12-01 (@m1well)
+### Added
+- added boolean variable to config to render calendar name in eventslist
+- added possibility to map a calendar name to a given string (maybe for formatting purposes)
+
+## [0.7.0] - 2021-11-19
 ### Added
 - added `/process date offsets` command: find date offset patterns and turn them into due dates, based on date at start of section, or a less-indented line, or the line itself.
 

--- a/jgclark.EventHelpers/README.md
+++ b/jgclark.EventHelpers/README.md
@@ -37,20 +37,24 @@ Or add the following settings into the `Templates/_configuration` note's first c
 ```jsonc
 ...
   events: {
-    calendarToWriteTo: "", // specify calendar name to write events to. Must be writable calendar. If empty, then the default system calendar will be used.
+    calendarToWriteTo: "",  // specify calendar name to write events to. Must be writable calendar. If empty, then the default system calendar will be used.
     addEventID: false,  // whether to add an '⏰event:ID' string when creating an event from a time block
-    processedTagName: "#event_created",   // optional tag to add after making a time block an event
-    confirmEventCreation: false, // optional tag to indicate whether to ask user to confirm each event to be created
+    processedTagName: "#event_created",  // optional tag to add after making a time block an event
+    confirmEventCreation: false,  // optional tag to indicate whether to ask user to confirm each event to be created
     removeTimeBlocksWhenProcessed: true,  // whether to remove time block after making an event from it
     eventsHeading: "### Events today",  // optional heading to put before list of today's events
     calendarSet: [],  // optional list of calendar names to filter by when showing list of events. If empty, no filtering will be done.
-    addMatchingEvents: {   // match events with string on left, and then the string on the right is the template for how to insert this event (see README for details)
+    addMatchingEvents: {  // match events with string on left, and then the string on the right is the template for how to insert this event (see README for details)
       "meeting": "### *|TITLE|* (*|START|*)\n*|NOTES|*",
       "webinar": "### *|TITLE|* (*|START|*) *|URL|*",
       "holiday": "*|TITLE|* *|NOTES|*",
     },
     locale: "en-US",
     timeOptions: { hour: '2-digit', minute: '2-digit', hour12: false }, // optional settings for time outputs
+    showCalendarName: false, // set to true if you want to have the calendarname
+    calendarNameMappings: [  // here you can map a calendar name to a new string - e.g. "Thomas" to "Me" with "Thomas;Me"
+      "From;To",
+    ],
   }
 ...
 ```
@@ -74,6 +78,8 @@ This uses JSON5 format: ensure there are commas at the end of all that lines tha
 - **eventsHeading**: in `/insert today's events as list` the heading to put before the list of today's events. Optional.
 - **calendarSet**: optional ["array","of calendar","names"] to filter by when showing list of events. If empty or missing, no filtering will be done.
 - **addMatchingEvents**: for `/add matching events` is a set of pairs of strings. The first string is what is matched for in an event's title. If it does match the second string is used as the template for how to insert the event details at the cursor.  This uses the same `*|TITLE|*`, `*|START|*` (time), `*|END|*` (time), `*|NOTES|*` and `*|URL|*` template items below ...  NB: At this point the 'location' field is unfortunately _not_ available through the API.
+- **showCalendarName**: optional - set to true if you want to see the calendarname (also add it to your string template!)
+- **calendarNameMappings**: optional - add mappings for your calendarnames - e.g. "Thomas;Me" - then in the Note following appears: `- Me: Event 1 (15:00)` (obviously it depends on your template) - maybe for formatting purposes
 
 ### Using Event Lists from a Template
 If you use Templates, this command can be called when a Template is inserted (including in the `/day start` command which applies your `Daily Note Template` file). To do this insert `{{events()}}` wherever you wish it to appear in the Template.  By default it gives a simple markdown list of event title and start time.  To **customise the list display**, you can add a `'template:"..."'` parameter to the `{{events()}}` template command that sets how to present the list, and a separate template for items with no start/end times (`'allday_template:"..."`).
@@ -83,10 +89,10 @@ If you want to disable the adding of the heading, add the following parameter `i
 For example:
 
 ```jsonc
-{{events({template:"### *|TITLE|* (*|START|*-*|END|*)\n*|NOTES|*",allday_template:"### TITLE",includeHeadings:false})}}
+{{events({template:"### *|CAL|**|TITLE|* (*|START|*-*|END|*)\n*|NOTES|*",allday_template:"### TITLE",includeHeadings:false})}}
 ```
 
-The `*|TITLE|*`, `*|START|*`, `*|END|*`, `*|NOTES|*` and `*|URL|*` can be mixed with whatever markdown characters or other text you like, and they will get replaced accordingly with the fields from each matching event found. (Note the difference between the } and ) bracket types, and use of double quotes around the template string. I didn't design this syntax ...)
+The `*|CAL|*`, `*|TITLE|*`, `*|START|*`, `*|END|*`, `*|NOTES|*` and `*|URL|*` can be mixed with whatever markdown characters or other text you like, and they will get replaced accordingly with the fields from each matching event found. (Note the difference between the } and ) bracket types, and use of double quotes around the template string. I didn't design this syntax ...)
 
 You can also place  `{{listMatchingEvents()}}` in Templates in a similar way, and similar customisation is possible. However, it is defined in a different way, using the matches and template strings defined in the `_configuration` file's `addMatchingEvents` array, as shown above.
 

--- a/jgclark.EventHelpers/README.md
+++ b/jgclark.EventHelpers/README.md
@@ -51,7 +51,6 @@ Or add the following settings into the `Templates/_configuration` note's first c
     },
     locale: "en-US",
     timeOptions: { hour: '2-digit', minute: '2-digit', hour12: false }, // optional settings for time outputs
-    showCalendarName: false, // set to true if you want to have the calendarname
     calendarNameMappings: [  // here you can map a calendar name to a new string - e.g. "Thomas" to "Me" with "Thomas;Me"
       "From;To",
     ],
@@ -78,7 +77,6 @@ This uses JSON5 format: ensure there are commas at the end of all that lines tha
 - **eventsHeading**: in `/insert today's events as list` the heading to put before the list of today's events. Optional.
 - **calendarSet**: optional ["array","of calendar","names"] to filter by when showing list of events. If empty or missing, no filtering will be done.
 - **addMatchingEvents**: for `/add matching events` is a set of pairs of strings. The first string is what is matched for in an event's title. If it does match the second string is used as the template for how to insert the event details at the cursor.  This uses the same `*|TITLE|*`, `*|START|*` (time), `*|END|*` (time), `*|NOTES|*` and `*|URL|*` template items below ...  NB: At this point the 'location' field is unfortunately _not_ available through the API.
-- **showCalendarName**: optional - set to true if you want to see the calendarname (also add it to your string template!)
 - **calendarNameMappings**: optional - add mappings for your calendarnames - e.g. "Thomas;Me" - then in the Note following appears: `- Me: Event 1 (15:00)` (obviously it depends on your template) - maybe for formatting purposes
 
 ### Using Event Lists from a Template
@@ -89,7 +87,7 @@ If you want to disable the adding of the heading, add the following parameter `i
 For example:
 
 ```jsonc
-{{events({template:"### *|CAL|**|TITLE|* (*|START|*-*|END|*)\n*|NOTES|*",allday_template:"### TITLE",includeHeadings:false})}}
+{{events({template:"### *|CAL|*: *|TITLE|* (*|START|*-*|END|*)\n*|NOTES|*",allday_template:"### TITLE",includeHeadings:false})}}
 ```
 
 The `*|CAL|*`, `*|TITLE|*`, `*|START|*`, `*|END|*`, `*|NOTES|*` and `*|URL|*` can be mixed with whatever markdown characters or other text you like, and they will get replaced accordingly with the fields from each matching event found. (Note the difference between the } and ) bracket types, and use of double quotes around the template string. I didn't design this syntax ...)

--- a/jgclark.EventHelpers/plugin.json
+++ b/jgclark.EventHelpers/plugin.json
@@ -7,7 +7,7 @@
   "plugin.icon": "",
   "plugin.author": "jgclark",
   "plugin.url": "https://github.com/NotePlan/plugins/tree/main/jgclark.EventHelpers",
-  "plugin.version": "0.7.0",
+  "plugin.version": "0.8.0",
   "plugin.dependencies": [],
   "plugin.script": "script.js",
   "plugin.isRemote": "false",

--- a/jgclark.EventHelpers/src/eventsToNotes.js
+++ b/jgclark.EventHelpers/src/eventsToNotes.js
@@ -5,13 +5,9 @@
 // @jgclark, with additions by @dwertheimer, @weyert
 // ------------------------------------------------------------------------------------
 
-import {
-  stringReplace,
-  // getTagParams,
-  getTagParamsFromString,
-} from '../../helpers/general'
+import { getTagParamsFromString, stringReplace, } from '../../helpers/general'
 import { showMessage } from '../../helpers/userInput'
-import { toLocaleTime, dateStringFromCalendarFilename } from '../../helpers/dateTime'
+import { dateStringFromCalendarFilename, toLocaleTime } from '../../helpers/dateTime'
 
 import { getOrMakeConfigurationSection } from '../../nmn.Templates/src/configuration'
 
@@ -19,19 +15,24 @@ import { getOrMakeConfigurationSection } from '../../nmn.Templates/src/configura
 // Get settings
 const DEFAULT_EVENTS_OPTIONS = `
   events: {
-    calendarToWriteTo: "", // specify calendar name to write events to. Must be writable calendar. If empty, then the default system calendar will be used.
+    calendarToWriteTo: "",  // specify calendar name to write events to. Must be writable calendar. If empty, then the default system calendar will be used.
     addEventID: false,  // whether to add an '⏰event:ID' internal link when creating an event from a time block
-    processedTagName: "#event_created",   // optional tag to add after making a time block an event
+    processedTagName: "#event_created",  // optional tag to add after making a time block an event
+    confirmEventCreation: false,  // optional tag to indicate whether to ask user to confirm each event to be created
     removeTimeBlocksWhenProcessed: true,  // whether to remove time block after making an event from it
     eventsHeading: "### Events today",  // optional heading to put before list of today's events
     calendarSet: [],  // optional ["array","of calendar","names"] to filter by when showing list of events. If empty or missing, no filtering will be done.
-    addMatchingEvents: {   // match events with string on left, and then the string on the right is the template for how to insert this event (see README for details)
+    addMatchingEvents: {  // match events with string on left, and then the string on the right is the template for how to insert this event (see README for details)
       "meeting": "### *|TITLE|* (*|START|*)\\n*|NOTES|*",
       "webinar": "### *|TITLE|* (*|START|*) *|URL|*",
       "holiday": "*|TITLE|* *|NOTES|*",
     },
     locale: "en-US",
-	  timeOptions: { hour: '2-digit', minute: '2-digit', hour12: false },
+    timeOptions: { hour: '2-digit', minute: '2-digit', hour12: false },
+    showCalendarName: false, // set to true if you want to have the calendarname
+    calendarNameMappings: [  // here you can map a calendar name to a new string - e.g. "Thomas" to "Me" with "Thomas;Me"
+      "From;To",
+    ],
   },
 `
 // global variables, including default settings
@@ -40,6 +41,8 @@ let pref_addMatchingEvents: ?{ [string]: mixed }
 let pref_locale: string
 let pref_timeOptions
 let pref_calendarSet: Array<string>
+let pref_showCalendarName: boolean
+let pref_calendarNameMappings: Array<string>
 
 //------------------------------------------------------------------------------
 // Local functions
@@ -88,6 +91,9 @@ async function getEventsSettings(): Promise<void> {
   // if (eventsConfig.timeOptions != null) {
   //   pref_timeOptions = eventsConfig.timeOptions
   // }
+  pref_showCalendarName = eventsConfig?.showCalendarName != null ? Boolean(eventsConfig?.showCalendarName) : false
+  // $FlowFixMe
+  pref_calendarNameMappings = eventsConfig?.calendarNameMappings ?? []
   console.log(`\tEnd of getEventsSettings()`)
 }
 
@@ -135,8 +141,8 @@ export async function listDaysEvents(paramString: string = ''): Promise<string> 
   await getEventsSettings()
   // Work out template for output line (from params, or if blank, a default)
   // NB: be aware that this call doesn't do type checking
-  const template = String(await getTagParamsFromString(paramString, 'template', '- *|TITLE|* (*|START|*)'))
-  const alldayTemplate = String(await getTagParamsFromString(paramString, 'allday_template', '- *|TITLE|*'))
+  const template = String(await getTagParamsFromString(paramString, 'template', '- *|CAL|**|TITLE|* (*|START|*)'))
+  const alldayTemplate = String(await getTagParamsFromString(paramString, 'allday_template', '- *|CAL|**|TITLE|*'))
   const includeHeadings = await getTagParamsFromString(paramString, 'includeHeadings', true)
   // console.log(`\toutput template: '${template}' and '${alldayTemplate}'`)
 
@@ -147,26 +153,8 @@ export async function listDaysEvents(paramString: string = ''): Promise<string> 
   let lastEventStr = '' // keep duplicates from multiple calendars out
   for (const e of eArr) {
     // console.log(`      for e: ${e.title}: ${JSON.stringify(e)}`)
-    const replacements = [
-      { key: '*|TITLE|*', value: e.title },
-      {
-        key: '*|START|*',
-        value: !e.isAllDay
-          ? // $FlowFixMe
-            toLocaleTime(e.date, pref_locale, pref_timeOptions)
-          : '',
-      },
-      {
-        key: '*|END|*',
-        value:
-          e.endDate != null && !e.isAllDay
-            ? // $FlowFixMe
-              toLocaleTime(e.endDate, pref_locale, pref_timeOptions)
-            : '',
-      },
-      { key: '*|NOTES|*', value: e.notes },
-      { key: '*|URL|*', value: e.url },
-    ]
+    const replacements = getReplacements(e)
+
     // NB: the following will replace any mentions of the keywords in the e.title string itself
     const thisEventStr = stringReplace(e.isAllDay ? alldayTemplate : template, replacements).trimEnd()
     if (lastEventStr !== thisEventStr) {
@@ -233,26 +221,7 @@ export async function listMatchingDaysEvents(
       const reMatch = new RegExp(textToMatchA[i], 'i')
       if (e.title.match(reMatch)) {
         console.log(`\tFound match to event '${e.title}'`)
-        const replacements = [
-          { key: '*|TITLE|*', value: e.title },
-          {
-            key: '*|START|*',
-            value: !e.isAllDay
-              ? // $FlowFixMe
-                toLocaleTime(e.date, pref_locale, pref_timeOptions)
-              : '',
-          },
-          {
-            key: '*|END|*',
-            value:
-              e.endDate != null && !e.isAllDay
-                ? // $FlowFixMe
-                  toLocaleTime(e.endDate, pref_locale, pref_timeOptions)
-                : '',
-          },
-          { key: '*|NOTES|*', value: e.notes },
-          { key: '*|URL|*', value: e.url },
-        ]
+        const replacements = getReplacements(e)
         // $FlowFixMe -- not sure how to deal with mixed coercing to strings
         const thisEventStr = stringReplace(template, replacements)
         if (lastEventStr !== thisEventStr) {
@@ -281,4 +250,48 @@ export async function insertMatchingDaysEvents(paramString: ?string): Promise<vo
 
   const output = await listMatchingDaysEvents(paramString || '')
   Editor.insertTextAtCursor(output)
+}
+
+/**
+ * @private
+ */
+const getReplacements = (item: TCalendarItem): { key: string, value: string }[] => {
+  return [
+    {
+      key: '*|CAL|*',
+      value: pref_showCalendarName ? calendarNameWithMapping(item.calendar, pref_calendarNameMappings) : ''
+    },
+    { key: '*|TITLE|*', value: item.title },
+    {
+      key: '*|START|*',
+      value: !item.isAllDay
+        ? // $FlowFixMe
+        toLocaleTime(item.date, pref_locale, pref_timeOptions)
+        : '',
+    },
+    {
+      key: '*|END|*',
+      value:
+        item.endDate != null && !item.isAllDay
+          ? // $FlowFixMe
+          toLocaleTime(item.endDate, pref_locale, pref_timeOptions)
+          : '',
+    },
+    { key: '*|NOTES|*', value: item.notes },
+    { key: '*|URL|*', value: item.url },
+  ]
+}
+
+/**
+ * @private
+ */
+const calendarNameWithMapping = (name: string, mappings: Array<string>): string => {
+  let mapped = name
+  mappings.forEach(mapping => {
+    const splitted = mapping.split(';')
+    if (splitted.length === 2 && name === splitted[0]) {
+      mapped = splitted[1]
+    }
+  })
+  return `${mapped}: `
 }

--- a/jgclark.EventHelpers/src/timeblocks.js
+++ b/jgclark.EventHelpers/src/timeblocks.js
@@ -25,19 +25,24 @@ import {
 // Settings
 const DEFAULT_EVENTS_OPTIONS = `
   events: {
-    calendarToWriteTo: "", // specify calendar name to write events to. Must be writable calendar. If empty, then the default system calendar will be used.
+    calendarToWriteTo: "",  // specify calendar name to write events to. Must be writable calendar. If empty, then the default system calendar will be used.
     addEventID: false,  // whether to add an '⏰event:ID' internal link when creating an event from a time block
-    processedTagName: "#event_created",   // optional tag to add after making a time block an event
+    processedTagName: "#event_created",  // optional tag to add after making a time block an event
+    confirmEventCreation: false,  // optional tag to indicate whether to ask user to confirm each event to be created
     removeTimeBlocksWhenProcessed: true,  // whether to remove time block after making an event from it
     eventsHeading: "### Events today",  // optional heading to put before list of today's events
     calendarSet: [],  // optional ["array","of calendar","names"] to filter by when showing list of events. If empty or missing, no filtering will be done.
-    addMatchingEvents: {   // match events with string on left, and then the string on the right is the template for how to insert this event (see README for details)
+    addMatchingEvents: {  // match events with string on left, and then the string on the right is the template for how to insert this event (see README for details)
       "meeting": "### *|TITLE|* (*|START|*)\\n*|NOTES|*",
       "webinar": "### *|TITLE|* (*|START|*) *|URL|*",
       "holiday": "*|TITLE|* *|NOTES|*",
     },
     locale: "en-US",
-	  timeOptions: { hour: '2-digit', minute: '2-digit', hour12: false },
+	timeOptions: { hour: '2-digit', minute: '2-digit', hour12: false },
+	showCalendarName: false, // set to true if you want to have the calendarname
+    calendarNameMappings: [  // here you can map a calendar name to a new string - e.g. "Thomas" to "Me" with "Thomas;Me"
+      "From;To",
+    ],
   },
 `
 


### PR DESCRIPTION
* since I do not know which files are all affected on the new templating system from @mikeerickson, the only thing I can do is to bring up my ideas - if you don't merge them then it's a pity but ok
* because I also see the calendar of my wife, it would be nice to have the possibility to see the calendar name in the eventslist
* also I added a mapping, so that you can map the calendar name, maybe for formatting purposes (as it is for me)