### PR TITLE
dailyjournal todaystart configurable templatename

### DIFF
--- a/jgclark.DailyJournal/README.md
+++ b/jgclark.DailyJournal/README.md
@@ -25,6 +25,7 @@ You configure the set of questions to ask in the `Templates/_configuration` note
 ```json5
 {
   dailyJournal: {
+    templateTitle: 'Daily Note Template',
     reviewSectionHeading: "Journal",
     reviewQuestions: "@work(<int>)\n@fruitveg(<int>)\nMood:: <mood>\nGratitude:: <string>\nGod was:: <string>\nAlive:: <string>\nNot Great:: <string>\nWife:: <string>\nRemember:: <string>",
     // NB: need to use "\n" for linebreaks rather than actual linebreaks, as even JSON5 doesn't fully support multi-line strings.
@@ -34,6 +35,8 @@ You configure the set of questions to ask in the `Templates/_configuration` note
 ```
 (This example is in JSON5 format: see the help text in `_configuration` note.)
 
+#### templateTitle
+The name of the template for `/dayStart` and `/todayStart`
 #### reviewSectionHeading
 The name of an existing markdown heading after which the review answers are added - if it doesn't exist, it is added at the end of the note
 #### reviewQuestions

--- a/jgclark.DailyJournal/README.md
+++ b/jgclark.DailyJournal/README.md
@@ -2,8 +2,8 @@
 This plugin provides two commands for daily journalling, including start-of-day template, and end-of-day review questions.  
 Both work on the currently open daily calendar note:
 
-- `/dayStart`: Apply your `Daily Note Template` to the currently open calendar note (which by default includes list of today's events and local weather lookup)
-- `/todayStart`: Apply your `Daily Note Template` to today's calendar note (which by default includes list of today's events and local weather lookup)
+- `/dayStart`: Apply your `Daily Note Template` (or configured template) to the currently open calendar note (which by default includes list of today's events and local weather lookup)
+- `/todayStart`: Apply your `Daily Note Template` (or configured template) to today's calendar note (which by default includes list of today's events and local weather lookup)
 - `/dayReview`: Ask journal questions for an end-of-day review in the currently open calendar note. See below for details and examples.
 
 ## Changes
@@ -15,7 +15,9 @@ This plugin requires prior installation of the [Templates plugin](https://github
 ## Configuration
 
 ### /dayStart and /todayStart
-`/dayStart` and `/todayStart` use the `Daily Note Template` note found in the `Templates` folder. If this note has not been added, it should prompt you to create one.
+`/dayStart` and `/todayStart` use the `Daily Note Template` note found in the `Templates` folder (or configure another one).  
+If this note has not been added, it should prompt you to create one.  
+Be careful with `/dayStart` in another calendar note than today and possible template tags like `{{date... / formattedDate...}}` or `{{weather()}}` -> because this renders the TODAY content!  
 For details of the commands you can use, including a list of events, a quote-of-the-day or summary weather forecast, see [Templates plugin README](https://github.com/NotePlan/plugins/tree/main/nmn.Templates/).
 
 ### /dayReview

--- a/jgclark.DailyJournal/plugin.json
+++ b/jgclark.DailyJournal/plugin.json
@@ -7,7 +7,7 @@
   "plugin.icon": "",
   "plugin.author": "Jonathan Clark",
   "plugin.url": "https://github.com/NotePlan/plugins/blob/main/jgclark.DailyJournal/README.md",
-  "plugin.version": "0.9.0",
+  "plugin.version": "0.10.0",
   "plugin.dependencies": [],
   "plugin.script": "script.js",
   "plugin.isRemote": "false",

--- a/jgclark.DailyJournal/src/journal.js
+++ b/jgclark.DailyJournal/src/journal.js
@@ -2,7 +2,7 @@
 //--------------------------------------------------------------------------------------------------------------------
 // Daily Journal plugin for NotePlan
 // Jonathan Clark
-// last update v0.9.0, 25.11.2021 by @jgclark/@m1well
+// last update v0.10.0, 07.12.2021 by @jgclark/@m1well
 //--------------------------------------------------------------------------------------------------------------------
 
 import { isInt, showMessage } from '../../helpers/userInput'
@@ -13,16 +13,18 @@ import { applyNamedTemplate } from '../../nmn.Templates/src/index'
 //--------------------------------------------------------------------------------------------------------------------
 // Settings
 const DEFAULT_JOURNAL_OPTIONS = `  dailyJournal: {
-    reviewSectionHeading: "Journal",
-    moods: "🤩 Great,🙂 Good,😇 Blessed,🥱 Tired,😫 Stressed,😤 Frustrated,😔 Low,🥵 Sick,Other",
-    reviewQuestions: "@sleep(<number>)\\n@work(<number>)\\n@fruitveg(<int>)\\nMood:: <mood>\\nExercise:: <string>\\nGratitude:: <string>\\nGod was:: <string>\\nAlive:: <string>\\nNot Great:: <string>\\nWife:: <string>\\nRemember:: <string>"
+    nameOfDailyNoteTemplate: 'Daily Note Template',
+    reviewSectionHeading: 'Journal',
+    moods: '🤩 Great,🙂 Good,😇 Blessed,🥱 Tired,😫 Stressed,😤 Frustrated,😔 Low,🥵 Sick,Other',
+    reviewQuestions: '@sleep(<number>)\\n@work(<number>)\\n@fruitveg(<int>)\\nMood:: <mood>\\nExercise:: <string>\\nGratitude:: <string>\\nGod was:: <string>\\nAlive:: <string>\\nNot Great:: <string>\\nWife:: <string>\\nRemember:: <string>'
   },
 `
 const MINIMUM_JOURNAL_OPTIONS = {
   reviewQuestions: 'string',
 }
 
-const pref_templateTitle = 'Daily Note Template' // fixed
+const defaultTemplateTitle = 'Daily Note Template'
+let pref_templateTitle: string
 let pref_reviewSectionHeading: string
 let pref_moodArray: Array<string>
 
@@ -54,6 +56,29 @@ export async function dayStart(today: boolean = false): Promise<void> {
       return
     }
   }
+
+  // Get config settings from Template folder _configuration note
+  const journalConfig = await getOrMakeConfigurationSection(
+    'dailyJournal',
+    DEFAULT_JOURNAL_OPTIONS,
+    MINIMUM_JOURNAL_OPTIONS,
+  )
+  // console.log(JSON.stringify(journalConfig))
+  if (journalConfig == null
+    || Object.keys(journalConfig).length === 0) // this is how to check for empty object
+  {
+    console.log('\tWarning: Cannot find suitable \'dailyJournal\' settings in Templates/_configuration note. Stopping.')
+    await showMessage(
+      'Cannot find \'dailyJournal\' settings in _configuration.',
+      'Yes, I\'ll check my _configuration settings.',
+    )
+    return
+  }
+
+  pref_templateTitle = (journalConfig?.nameOfDailyNoteTemplate != null)
+    ? String(journalConfig?.nameOfDailyNoteTemplate)
+    : defaultTemplateTitle
+
   await applyNamedTemplate(pref_templateTitle)
 }
 

--- a/jgclark.DailyJournal/src/journal.js
+++ b/jgclark.DailyJournal/src/journal.js
@@ -2,7 +2,7 @@
 //--------------------------------------------------------------------------------------------------------------------
 // Daily Journal plugin for NotePlan
 // Jonathan Clark
-// last update v0.10.0, 07.12.2021 by @jgclark/@m1well
+// last update v0.10.0, 07.12.2021 by @m1well
 //--------------------------------------------------------------------------------------------------------------------
 
 import { isInt, showMessage } from '../../helpers/userInput'
@@ -13,7 +13,7 @@ import { applyNamedTemplate } from '../../nmn.Templates/src/index'
 //--------------------------------------------------------------------------------------------------------------------
 // Settings
 const DEFAULT_JOURNAL_OPTIONS = `  dailyJournal: {
-    nameOfDailyNoteTemplate: 'Daily Note Template',
+    templateTitle: 'Daily Note Template',
     reviewSectionHeading: 'Journal',
     moods: '🤩 Great,🙂 Good,😇 Blessed,🥱 Tired,😫 Stressed,😤 Frustrated,😔 Low,🥵 Sick,Other',
     reviewQuestions: '@sleep(<number>)\\n@work(<number>)\\n@fruitveg(<int>)\\nMood:: <mood>\\nExercise:: <string>\\nGratitude:: <string>\\nGod was:: <string>\\nAlive:: <string>\\nNot Great:: <string>\\nWife:: <string>\\nRemember:: <string>'
@@ -75,8 +75,8 @@ export async function dayStart(today: boolean = false): Promise<void> {
     return
   }
 
-  pref_templateTitle = (journalConfig?.nameOfDailyNoteTemplate != null)
-    ? String(journalConfig?.nameOfDailyNoteTemplate)
+  pref_templateTitle = (journalConfig?.templateTitle != null)
+    ? String(journalConfig?.templateTitle)
     : defaultTemplateTitle
 
   await applyNamedTemplate(pref_templateTitle)


### PR DESCRIPTION
* template name for `/todayStart` and `/dayStart` is now configurable 
* i also added a hint in the README that one has to be careful with `/dayStart` on another day than today with tags like `date... / formattedDate...` and `weather()`