### PR TITLE
expenses plugin amount format

### DIFF
--- a/m1well.Expenses/CHANGELOG.md
+++ b/m1well.Expenses/CHANGELOG.md
@@ -1,5 +1,9 @@
 # m1well.Expenses Plugin Changelog
 
+## [1.4.0] - 2021-12-15 (@m1well)
+### Changed
+* configurable amount format (`full` with always 2 fraction digits or `short` with no fraction digits and always rounded)
+
 ## [1.3.0] - 2021-12-09 (@m1well) (some ideas from @dwertheimer)
 because of breaking changes, normally this should give a new major version.  
 but because I assume that no one has yet installed this plugin, a minor version would be ok

--- a/m1well.Expenses/README.md
+++ b/m1well.Expenses/README.md
@@ -16,8 +16,13 @@ which will be added to the NotePlan `_configuration` on the first usage!
 * `dateFormat`
   * choose custom date format like `yyyy-MM-dd` or `yyyy-MM` if you don't care about the days
   * ATTENTION: don't use your chosen delimiter here in the date format
+  * ATTENTION: please don't change this after first tracking
+* `amountFormat`
+  * choose either `full` to have always 2 fraction digits with localized separator and exact amount, or `short` to have no fraction digits and rounded amount
+  * ATTENTION: please don't change this after first tracking
 * `columnOrder`
   * choose column order - e.g. `['date', 'category', 'text', 'amount']`
+  * ATTENTION: please don't change this after first tracking
 * `categories`
   * Categories of your expenses, e.g. 'Living', 'Groceries', 'Insurances', 'Media'
 * `shortcutExpenses`
@@ -33,6 +38,7 @@ which will be added to the NotePlan `_configuration` on the first usage!
     folderPath: 'finances',
     delimiter: ';',
     dateFormat: 'yyyy-MM-dd',
+    amountFormat: 'short',
     columnOrder: [
       'date',
       'category',
@@ -82,7 +88,7 @@ which will be added to the NotePlan `_configuration` on the first usage!
       {
         category: 'Media',
         text: 'Spotify',
-        amount: 10,
+        amount: 9.99,
         month: 0,
         active: false,
       },
@@ -94,8 +100,6 @@ which will be added to the NotePlan `_configuration` on the first usage!
 ## Hints
 * for the sake of simplicity you can't change written lines or add older entries
   * for that you have to add/change/remove the lines manually
-* To avoid problems with separator over different countries, only use integer values please
-  (e.g. instead of '9.99' use '10') - the plugin does a `Math.round()` anyways
 * Avoid empty lines in the Note, the plugin does not recognize them
 
 ## Commands

--- a/m1well.Expenses/__tests__/expensesChecks.test.js
+++ b/m1well.Expenses/__tests__/expensesChecks.test.js
@@ -6,6 +6,7 @@ const SIMPLE_CONFIG = {
   folderPath: 'folder',
   delimiter: '%',
   dateFormat: 'yyyy-MM-dd',
+  amountFormat: 'short',
   columnOrder: [
     'date', 'category', 'text', 'amount'
   ],
@@ -77,6 +78,7 @@ describe('expensesChecks', () => {
       expect(result).toEqual(SIMPLE_CONFIG)
       expect(CONSOLE_SPY).toHaveBeenCalledWith('\texpenses log: no delimiter configured - set default to \';\'')
     })
+
     test('should check incomplete config and throw error because no folder path', () => {
       const defaultDelimiter = ';'
       delete SIMPLE_CONFIG.folderPath

--- a/m1well.Expenses/__tests__/expensesHelper.test.js
+++ b/m1well.Expenses/__tests__/expensesHelper.test.js
@@ -14,6 +14,7 @@ import {
 const simpleConfig = {
   delimiter: ';',
   dateFormat: 'yyyy-MM-dd',
+  amountFormat: 'short',
   columnOrder: [
     'date', 'category', 'text', 'amount'
   ],
@@ -128,6 +129,21 @@ describe('expensesHelper', () => {
       const result = createTrackingExpenseRowWithConfig(row, simpleConfig)
 
       expect(result).toEqual('2021-11-01;Living;Flat Rent;600')
+    })
+
+    test('should create line in given order with full amount format', () => {
+      const row = {
+        date: new Date(2021, 10, 1),
+        category: 'Living',
+        text: 'Flat Rent',
+        amount: 600.55,
+      }
+
+      const changedSimpleConfig = { ...simpleConfig, amountFormat: 'full' }
+
+      const result = createTrackingExpenseRowWithConfig(row, changedSimpleConfig)
+
+      expect(result).toEqual('2021-11-01;Living;Flat Rent;600.55')
     })
 
     test('should left pad with zeros', () => {

--- a/m1well.Expenses/plugin.json
+++ b/m1well.Expenses/plugin.json
@@ -7,7 +7,7 @@
   "plugin.icon": "",
   "plugin.author": "@m1well",
   "plugin.url": "https://github.com/NotePlan/plugins/blob/main/m1well.Expenses/README.md",
-  "plugin.version": "1.3.0",
+  "plugin.version": "1.4.0",
   "plugin.dependencies": [],
   "plugin.script": "script.js",
   "plugin.isRemote": "false",

--- a/m1well.Expenses/src/expensesChecks.js
+++ b/m1well.Expenses/src/expensesChecks.js
@@ -4,6 +4,11 @@ import { format } from 'date-fns'
 import { showMessage } from '../../helpers/userInput'
 import type { Config } from './expensesModels'
 
+const DEFAULT_DELIMITER = ';'
+const ALLOWED_DELIMTER = [ ';', '%', 'TAB' ]
+const MINIMAL_COLUMNS = [ 'date', 'category', 'amount' ]
+const ALLOWED_AMOUNT_FORMATS = [ 'full', 'short' ]
+
 /**
  * @description check if the amount is smaller than 1_000_000 and greater than -1_000_000 and is not 0 or null or NaN
  *
@@ -30,19 +35,15 @@ export const categoryOk = (category: string, categories: string[]): boolean => {
  *
  * @param config casted config from _configuration
  * @param currentDate current date - to have always the same
- * @param defaultDelimiter default delimiter from code
- * @param allowedDelimiter allowed delimiter from code
  * @returns {Config|null} return the config if everything is ok, otherwise null
  */
-export const validateConfig = (config: Config,
-                               currentDate: Date,
-                               defaultDelimiter: string,
-                               allowedDelimiter: string[]): Config => {
+export const validateConfig = (config: Config, currentDate: Date): Config => {
 
-  const emptyConfig = {
+  const emptyConfig: Config = {
     folderPath: '',
     delimiter: '',
     dateFormat: '',
+    amountFormat: '',
     columnOrder: [],
     categories: [],
     shortcutExpenses: [],
@@ -57,20 +58,25 @@ export const validateConfig = (config: Config,
 
   if (!config.delimiter) {
     // if there is no delimiter configured, then set default
-    logMessage(`no delimiter configured - set default to '${defaultDelimiter}'`)
-    config.delimiter = defaultDelimiter
+    logMessage(`no delimiter configured - set default to '${DEFAULT_DELIMITER}'`)
+    config.delimiter = DEFAULT_DELIMITER
   } else {
-    if (!allowedDelimiter.includes(config.delimiter)) {
+    if (!ALLOWED_DELIMTER.includes(config.delimiter)) {
       // if wrong delimiter configured, then stop
       logError(`wrong delimiter configured (${config.delimiter})`)
       return emptyConfig
     }
   }
 
-  const minimalColumns = [ 'date', 'category', 'amount' ]
-  if (config.columnOrder.every(col => minimalColumns.includes(col))) {
+  if (config.columnOrder.every(col => MINIMAL_COLUMNS.includes(col))) {
     // if minimal columns config is not provided, then stop
     logError('minimal columns config not provided (at least date, category, amount)')
+    return emptyConfig
+  }
+
+  if (!config.amountFormat || !ALLOWED_AMOUNT_FORMATS.includes(config.amountFormat)) {
+    // if no amount format or wrong amount format, then stop
+    logError('no or wrong amount format provided')
     return emptyConfig
   }
 

--- a/m1well.Expenses/src/expensesModels.js
+++ b/m1well.Expenses/src/expensesModels.js
@@ -4,6 +4,7 @@ export type Config = {
   folderPath: string,
   delimiter: string,
   dateFormat: string,
+  amountFormat: string,
   columnOrder: string[],
   categories: string[],
   shortcutExpenses: ShortcutExpense[],

--- a/m1well.Expenses/src/index.js
+++ b/m1well.Expenses/src/index.js
@@ -3,7 +3,7 @@
 // -----------------------------------------------------------------------------
 // Plugin to store your expenses for further analyis
 // Michael Wellner (@m1well)
-// v1.1.0, 04.12.2021
+// v1.4.0, 15.12.2021
 // -----------------------------------------------------------------------------
 
 export { expensesTracking, expensesAggregate, individualTracking, shortcutsTracking, fixedTracking } from './expenses'


### PR DESCRIPTION
added possibility to choose
* `full` amount format (always with 2 fraction digits)
* or `short` as it currently is - with no fraction digits and always rounded