### PR TITLE
introduce new utils plugin

### DIFF
--- a/Plugin-Listing.md
+++ b/Plugin-Listing.md
@@ -5,9 +5,10 @@
 | `Create AutoTimeBlocks using presets` | Read >today todos and insert them into today's calendar note as timeblocks, but using presets defined in _configuration note | 🗓 Event Automations |
 | `Create Note From Calendar Event` | creates a note from a calendar event | 🗓 Event Automations |
 | `Create Note From Calendar Event w/QuickTemplate` | creates a note from a calendar event | 🗓 Event Automations |
-| `add project` | add a new note representing a project, asking for its metadata | 🔬Reviews |
 | `apply template` | Choose a Template to apply (append) to the current Note | 🔩 Templates |
 | `atb - Create AutoTimeBlocks for >today's Tasks` | Read >today todos and insert them into today's calendar note as timeblocks | 🗓 Event Automations |
+| `autoArchiveNotes` | Provides possibility to auto archive notes with a specific tag and a given lifetime (moves note to @Archive) | 🛠 Utils |
+| `cleanUpEmptyLinesInFuture` | Remove empty lines in future daily notes | 🛠 Utils |
 | `complete project` | add @completed(today) date to the open project | 🔬Reviews |
 | `convertSelectionToHtml` | Convert current selection to HTML | 🧩 Codedungeon Toolbox |
 | `convertToHtml` | Convert current note to HTML | 🧩 Codedungeon Toolbox |
@@ -60,8 +61,10 @@
 | `quick prepend task to daily note` | Quickly prepend a task to a chosen daily note | ⚡️ Quick Capture |
 | `quick prepend task to note` | Quickly prepend a task to a chosen project note | ⚡️ Quick Capture |
 | `reorderList` | Reorder current ordered list | 🧩 Codedungeon Toolbox |
+| `repeater` | Repeat task(s) just by selecting them in whatever note you want with a lot of functionalities | 🛠 Utils |
 | `rpt` | Generate new @repeat() tasks from completed ones | 🔁 @repeat Extensions |
 | `saveSearchResults` | Save results from a search over all notes | 🗃 Summaries |
+| `sorter` | Sort selected lines by type and by prio | 🛠 Utils |
 | `start reviews` | start a new series of reviews, deciding which are now ready for review, and kicking off the first one | 🔬Reviews |
 | `sw7` | Find all open tasks for last 7 days & silently move/reschedule to today | 🧹 Task Sweeper |
 | `swa` | Find ALL open tasks & move/reschedule to today's Calendar Note | 🧹 Task Sweeper |

--- a/Plugin-Listing.md
+++ b/Plugin-Listing.md
@@ -64,7 +64,7 @@
 | `repeater` | Repeat task(s) just by selecting them in whatever note you want with a lot of functionalities | 🛠 Utils |
 | `rpt` | Generate new @repeat() tasks from completed ones | 🔁 @repeat Extensions |
 | `saveSearchResults` | Save results from a search over all notes | 🗃 Summaries |
-| `sorter` | Sort selected lines by type and by prio | 🛠 Utils |
+| `selectionSorter` | Sort selected lines by type and by prio | 🛠 Utils |
 | `start reviews` | start a new series of reviews, deciding which are now ready for review, and kicking off the first one | 🔬Reviews |
 | `sw7` | Find all open tasks for last 7 days & silently move/reschedule to today | 🧹 Task Sweeper |
 | `swa` | Find ALL open tasks & move/reschedule to today's Calendar Note | 🧹 Task Sweeper |

--- a/Plugin-Listing.md
+++ b/Plugin-Listing.md
@@ -6,8 +6,8 @@
 | `Create Note From Calendar Event` | creates a note from a calendar event | 🗓 Event Automations |
 | `Create Note From Calendar Event w/QuickTemplate` | creates a note from a calendar event | 🗓 Event Automations |
 | `apply template` | Choose a Template to apply (append) to the current Note | 🔩 Templates |
+| `archiveNotes` | Provides possibility to archive notes with a specific tag and a given lifetime (moves note to @Archive) | 🛠 Utils |
 | `atb - Create AutoTimeBlocks for >today's Tasks` | Read >today todos and insert them into today's calendar note as timeblocks | 🗓 Event Automations |
-| `autoArchiveNotes` | Provides possibility to auto archive notes with a specific tag and a given lifetime (moves note to @Archive) | 🛠 Utils |
 | `cleanUpEmptyLinesInFuture` | Remove empty lines in future daily notes | 🛠 Utils |
 | `complete project` | add @completed(today) date to the open project | 🔬Reviews |
 | `convertSelectionToHtml` | Convert current selection to HTML | 🧩 Codedungeon Toolbox |

--- a/m1well.Utils/CHANGELOG.md
+++ b/m1well.Utils/CHANGELOG.md
@@ -1,0 +1,5 @@
+# m1well.Utils Changelog
+
+## [1.0.0] - 2022-01-05 (@m1well)
+### Added
+* initial releaase

--- a/m1well.Utils/README.md
+++ b/m1well.Utils/README.md
@@ -1,0 +1,98 @@
+# m1well.Utils NotePlan Plugin
+This is a small collection of very useful functions I currently use nearly every day.  
+**Future of this plugin:**  
+If the core team provides kind of a "api styled" plugin, then it is of course absolutely ok for me to outsource these functions there and remove this plugin  
+But currently I don't see any possibility for something like this and I still want to share these useful functions with you
+
+## Commands
+Using the NotePlan Plugin Shortcut `/`
+
+### ->> `/util:repeater` <<-
+"Repeat task(s) just by selecting them in whatever note you want with a lot of functionalities"  
+
+**ATTENTION:**
+- Currently it isn't possible to programatically create future daily notes (it is - but it is not that safe)
+- so before you use the repeater, make sure you have the required notes
+- how to create them - see my thoughts on `## Future Daily Notes`
+
+**HOW TO:**
+1. select one ore more lines you want to repeat (they doesn't have to be tasks, they are automatically converted to tasks for the repeats)
+2. choose a future start date (or leave it empty for using tomorrow)
+3. choose any option you want:
+   - Day -> repeat task every day
+   - Week -> repeat task every week (every seven days)
+   - 2 Weeks -> repeat task every 2 weeks (every fourteen days)
+   - Month -> repeat task every month
+   - 2 Months -> repeat task every 2 months
+   - Quarter-year -> repeat task every quarter-year (every three months)
+   - Half-year -> repeat task every half-year (every six months)
+   - Year -> repeat task every year
+   - Special -> described down below
+4. special options:
+   - Every special weekday -> e.g. every monday or every saturday
+   - Every nth day of month -> e.g. every first day of month, or 5. day of month, or last day of month, etc.
+5. choose repetitions -> how often should the task repeat incl. the first occurrence
+
+**ADVANTAGES:**
+- the `@repeat` is now at the first occurence, so if you want to delete all repetitions, you just have to delete this first one
+- the last `@repeat` is BOLD, so that you are reminded to eventually create new repetitions again: example: @repeat(**!!15/15!!**)
+
+### ->> `/util:sorter` <<-
+"Sort selected lines by type and by prio ("inline sort" - so they stay at the same position in the note)"  
+
+**ATTENTION:**
+- To sort the tasks inline obviously I have to remove them
+- If there are tasks with repeats, then you get asked if you want to remove - just click "No" please 
+- Also depending on this question: if there are one or more `@repeat` in your selection, please select the WHOLE lines, because the question for deleting repeats "breaks" something if you don't select the whole upper line
+- **I do not guarantee for disappeared repeats!**  
+
+**SORT CRITERIA:**
+1. open
+2. scheduled
+3. cancelled
+4. done
+5. list
+6. text
+and each of them also sorts itself by prio with the `!!!`, `!!` and `!`
+
+### ->> `/util:autoArchiveNotes` <<-
+"Provides possibility to auto archive notes with a specific tag and a given lifetime (moves note to @Archive)"  
+
+**ATTENTION:**
+- the lifetime thing works with the `createdDate` of the file (there is no other hidden feature)
+- since NotePlan is file based you have to be careful now of course
+- if you do a backup on your own, you have to look if it overwrites the `createdDate`
+
+**HOW TO:**
+1. configure `autoArchiveTag` and `autoArchiveLifeInDays`
+2. add this configured tag to notes which you want to automatically archive
+3. call this function wherever you want
+4. all notes with this specific tag and the achieved lifetime are moved to the `@Archive` folder
+
+### ->> `/util:cleanUpEmptyLinesInFuture` <<-
+"Remove empty lines in future daily notes"  
+This is just a possibility to remove empty lines in future notes.  
+Because I just quickly create tasks in the future, (by hand or with my own custom BulletJournal plugin) it can also happen that there is an empty line (mostly at the end of the note).  
+And this function removes all empty lines in the future to have clean notes.  
+
+**HOW TO:**
+1. Provide a future date to which the daily notes get cleaned up
+
+## Future Daily Notes
+Because it is currently not possible to create future daily notes programatically safe, i have discovered another way.  
+But this only works on Mac, not on iPhone/iPad, because you need a commandline.  
+Here are the steps:
+1. open terminal window on NotePlan root folder
+2. create empty calendar notes for the future (e.g. for 2 years from now = 730 days):  
+   `for i in {0..730}; do dd=$(date -v "+${i}d" '+%Y%m%d'); touch ./Calendar/${dd}.md; done`  
+   -> content of existing notes in the future doesn't change!
+3. if you want to use the repeater to add tasks for more years in the future, then obviously you have to create more notes
+4. if you are done with your repeats, you can remove the empty notes with `find ./Calendar -type f -empty -delete`
+5. I also recommend having always empty notes for at least 2 years, to add some repeats for the next months, without thinking of the future notes
+
+## Changelog
+Here you can find the [Changelog](./CHANGELOG.md)
+If you change something in the code, please create a new version and update the changelog file
+
+## Author
+Michael Wellner | [Github](https://github.com/m1well) | [Twitter](https://twitter.com/m1well) | [Homepage](https://m1well.com)

--- a/m1well.Utils/README.md
+++ b/m1well.Utils/README.md
@@ -7,7 +7,7 @@ But currently I don't see any possibility for something like this and I still wa
 ## Commands
 Using the NotePlan Plugin Shortcut `/`
 
-### ->> `/util:repeater` <<-
+### ->> `/well:repeater` <<-
 "Repeat task(s) just by selecting them in whatever note you want with a lot of functionalities"  
 
 **ATTENTION:**
@@ -37,7 +37,7 @@ Using the NotePlan Plugin Shortcut `/`
 - the `@repeat` is now at the first occurence, so if you want to delete all repetitions, you just have to delete this first one
 - the last `@repeat` is BOLD, so that you are reminded to eventually create new repetitions again: example: @repeat(**!!15/15!!**)
 
-### ->> `/util:sorter` <<-
+### ->> `/well:sorter` <<-
 "Sort selected lines by type and by prio ("inline sort" - so they stay at the same position in the note)"  
 
 **ATTENTION:**
@@ -55,8 +55,8 @@ Using the NotePlan Plugin Shortcut `/`
 6. text
 and each of them also sorts itself by prio with the `!!!`, `!!` and `!`
 
-### ->> `/util:autoArchiveNotes` <<-
-"Provides possibility to auto archive notes with a specific tag and a given lifetime (moves note to @Archive)"  
+### ->> `/well:archiveNotes` <<-
+"Provides possibility to archive notes with a specific tag and a given lifetime (moves note to @Archive)"  
 
 **ATTENTION:**
 - the lifetime thing works with the `createdDate` of the file (there is no other hidden feature)
@@ -64,12 +64,12 @@ and each of them also sorts itself by prio with the `!!!`, `!!` and `!`
 - if you do a backup on your own, you have to look if it overwrites the `createdDate`
 
 **HOW TO:**
-1. configure `autoArchiveTag` and `autoArchiveLifeInDays`
+1. configure `archiveNotesTag` and `archiveNotesLifeInDays`
 2. add this configured tag to notes which you want to automatically archive
 3. call this function wherever you want
 4. all notes with this specific tag and the achieved lifetime are moved to the `@Archive` folder
 
-### ->> `/util:cleanUpEmptyLinesInFuture` <<-
+### ->> `/well:cleanUpEmptyLinesInFuture` <<-
 "Remove empty lines in future daily notes"  
 This is just a possibility to remove empty lines in future notes.  
 Because I just quickly create tasks in the future, (by hand or with my own custom BulletJournal plugin) it can also happen that there is an empty line (mostly at the end of the note).  

--- a/m1well.Utils/README.md
+++ b/m1well.Utils/README.md
@@ -37,7 +37,7 @@ Using the NotePlan Plugin Shortcut `/`
 - the `@repeat` is now at the first occurence, so if you want to delete all repetitions, you just have to delete this first one
 - the last `@repeat` is BOLD, so that you are reminded to eventually create new repetitions again: example: @repeat(**!!15/15!!**)
 
-### ->> `/well:sorter` <<-
+### ->> `/well:selectionSorter` <<-
 "Sort selected lines by type and by prio ("inline sort" - so they stay at the same position in the note)"  
 
 **ATTENTION:**

--- a/m1well.Utils/__tests__/utilsHelper.test.js
+++ b/m1well.Utils/__tests__/utilsHelper.test.js
@@ -8,35 +8,35 @@ global.Editor = {
     paragraphs: [
       {
         type: 'open',
-        content: 'aaaaa',
+        content: 'normal task 1',
       },
       {
-        type: 'text',
-        content: 'bbbbb',
+        type: 'open',
+        content: '! prio 2 task',
+      },
+      {
+        type: 'list',
+        content: 'list line',
       },
       {
         type: 'cancelled',
-        content: 'ccccc',
+        content: 'cancelled task',
       },
       {
-        type: 'list',
-        content: 'ddddd',
+        type: 'done',
+        content: 'done task',
       },
       {
         type: 'scheduled',
-        content: 'eeeee',
+        content: 'scheduled task >2022-12-12',
       },
       {
         type: 'open',
-        content: '! fffff',
+        content: '!! prio 1 task',
       },
       {
-        type: 'open',
-        content: '!! ggggg',
-      },
-      {
-        type: 'list',
-        content: '! hhhhh',
+        type: 'text',
+        content: 'some text',
       },
     ]
   }
@@ -74,37 +74,37 @@ describe('utilsHelper', () => {
     test('should sort by type and prio', () => {
       const expected = [
         {
-          type: 'open',
-          content: '!! ggggg',
+          "content": "!! prio 1 task",
+          "type": "open"
         },
         {
-          type: 'open',
-          content: '! fffff',
+          "content": "! prio 2 task",
+          "type": "open"
         },
         {
-          type: 'open',
-          content: 'aaaaa',
+          "content": "normal task 1",
+          "type": "open"
         },
         {
-          type: 'scheduled',
-          content: 'eeeee',
+          "content": "scheduled task >2022-12-12",
+          "type": "scheduled"
         },
         {
-          type: 'cancelled',
-          content: 'ccccc',
+          "content": "cancelled task",
+          "type": "cancelled"
         },
         {
-          type: 'list',
-          content: '! hhhhh',
+          "content": "done task",
+          "type": "done"
         },
         {
-          type: 'list',
-          content: 'ddddd',
+          "content": "list line",
+          "type": "list"
         },
         {
-          type: 'text',
-          content: 'bbbbb',
-        },
+          "content": "some text",
+          "type": "text"
+        }
       ]
 
       const result = Editor.note.paragraphs.sort(sortByType()).sort(sortByPrio())

--- a/m1well.Utils/__tests__/utilsHelper.test.js
+++ b/m1well.Utils/__tests__/utilsHelper.test.js
@@ -12,7 +12,11 @@ global.Editor = {
       },
       {
         type: 'open',
-        content: '! prio 2 task',
+        content: '!!! prio task with 3 excl.',
+      },
+      {
+        type: 'open',
+        content: '! prio task with 1 excl.',
       },
       {
         type: 'list',
@@ -32,11 +36,15 @@ global.Editor = {
       },
       {
         type: 'open',
-        content: '!! prio 1 task',
+        content: '!! prio task with 2 excl.',
       },
       {
         type: 'text',
         content: 'some text',
+      },
+      {
+        type: 'open',
+        content: '!!!! prio task with 4 excl.',
       },
     ]
   }
@@ -74,11 +82,19 @@ describe('utilsHelper', () => {
     test('should sort by type and prio', () => {
       const expected = [
         {
-          "content": "!! prio 1 task",
+          "content": "!!!! prio task with 4 excl.",
           "type": "open"
         },
         {
-          "content": "! prio 2 task",
+          "content": "!!! prio task with 3 excl.",
+          "type": "open"
+        },
+        {
+          "content": "!! prio task with 2 excl.",
+          "type": "open"
+        },
+        {
+          "content": "! prio task with 1 excl.",
           "type": "open"
         },
         {

--- a/m1well.Utils/__tests__/utilsHelper.test.js
+++ b/m1well.Utils/__tests__/utilsHelper.test.js
@@ -1,0 +1,117 @@
+/* global describe, expect, test, afterAll */
+
+const { castStringFromMixed, castNumberFromMixed, sortByPrio, sortByType } = require('../src/utilsHelper')
+
+// unsorted paragraphs
+global.Editor = {
+  note: {
+    paragraphs: [
+      {
+        type: 'open',
+        content: 'aaaaa',
+      },
+      {
+        type: 'text',
+        content: 'bbbbb',
+      },
+      {
+        type: 'cancelled',
+        content: 'ccccc',
+      },
+      {
+        type: 'list',
+        content: 'ddddd',
+      },
+      {
+        type: 'scheduled',
+        content: 'eeeee',
+      },
+      {
+        type: 'open',
+        content: '! fffff',
+      },
+      {
+        type: 'open',
+        content: '!! ggggg',
+      },
+      {
+        type: 'list',
+        content: '! hhhhh',
+      },
+    ]
+  }
+}
+
+const simpleConfig = {
+  autoArchiveTag: '#scratch',
+  autoArchiveLifeInDays: 7,
+}
+
+afterAll(() => {
+  delete global.Editor
+})
+
+describe('utilsHelper', () => {
+
+  describe('utilsHelper.js', () => {
+
+    test('should cast string from mixed config', () => {
+      const expected = '#scratch'
+
+      const result = castStringFromMixed(simpleConfig, 'autoArchiveTag')
+
+      expect(result).toEqual(expected)
+    })
+
+    test('should cast number from mixed config', () => {
+      const expected = 7
+
+      const result = castNumberFromMixed(simpleConfig, 'autoArchiveLifeInDays')
+
+      expect(result).toEqual(expected)
+    })
+
+    test('should sort by type and prio', () => {
+      const expected = [
+        {
+          type: 'open',
+          content: '!! ggggg',
+        },
+        {
+          type: 'open',
+          content: '! fffff',
+        },
+        {
+          type: 'open',
+          content: 'aaaaa',
+        },
+        {
+          type: 'scheduled',
+          content: 'eeeee',
+        },
+        {
+          type: 'cancelled',
+          content: 'ccccc',
+        },
+        {
+          type: 'list',
+          content: '! hhhhh',
+        },
+        {
+          type: 'list',
+          content: 'ddddd',
+        },
+        {
+          type: 'text',
+          content: 'bbbbb',
+        },
+      ]
+
+      const result = Editor.note.paragraphs.sort(sortByType()).sort(sortByPrio())
+
+      expect(result).toEqual(expected)
+    })
+
+  })
+
+})

--- a/m1well.Utils/plugin.json
+++ b/m1well.Utils/plugin.json
@@ -18,10 +18,10 @@
       "jsFunction": "repeater"
     },
     {
-      "name": "sorter",
-      "alias": ["well:sorter", "well"],
+      "name": "selectionSorter",
+      "alias": ["well:selectionSorter", "well"],
       "description": "Sort selected lines by type and by prio",
-      "jsFunction": "sorter"
+      "jsFunction": "selectionSorter"
     },
     {
       "name": "archiveNotes",

--- a/m1well.Utils/plugin.json
+++ b/m1well.Utils/plugin.json
@@ -1,0 +1,39 @@
+{
+  "noteplan.minAppVersion": "3.0.25",
+  "macOS.minVersion": "10.13.0",
+  "iOS.minVersion": "14",
+  "plugin.id": "m1well.Utils",
+  "plugin.name": "🛠 Utils",
+  "plugin.description": "Plugin for some Utils like repeat selected task, etc.",
+  "plugin.author": "@m1well",
+  "plugin.url": "https://github.com/NotePlan/plugins/blob/main/m1well.Utils/README.md",
+  "plugin.version": "1.0.0",
+  "plugin.dependencies": [],
+  "plugin.script": "script.js",
+  "plugin.commands": [
+    {
+      "name": "repeater",
+      "alias": ["util:repeater", "util"],
+      "description": "Repeat task(s) just by selecting them in whatever note you want with a lot of functionalities",
+      "jsFunction": "repeater"
+    },
+    {
+      "name": "sorter",
+      "alias": ["util:sorter", "util"],
+      "description": "Sort selected lines by type and by prio",
+      "jsFunction": "sorter"
+    },
+    {
+      "name": "autoArchiveNotes",
+      "alias": ["util:autoArchiveNotes", "util"],
+      "description": "Provides possibility to auto archive notes with a specific tag and a given lifetime (moves note to @Archive)",
+      "jsFunction": "autoArchiveNotes"
+    },
+    {
+      "name": "cleanUpEmptyLinesInFuture",
+      "alias": ["util:cleanUpEmptyLinesInFuture", "util"],
+      "description": "Remove empty lines in future daily notes",
+      "jsFunction": "cleanUpEmptyLinesInFuture"
+    }
+  ]
+}

--- a/m1well.Utils/plugin.json
+++ b/m1well.Utils/plugin.json
@@ -13,25 +13,25 @@
   "plugin.commands": [
     {
       "name": "repeater",
-      "alias": ["util:repeater", "util"],
+      "alias": ["well:repeater", "well"],
       "description": "Repeat task(s) just by selecting them in whatever note you want with a lot of functionalities",
       "jsFunction": "repeater"
     },
     {
       "name": "sorter",
-      "alias": ["util:sorter", "util"],
+      "alias": ["well:sorter", "well"],
       "description": "Sort selected lines by type and by prio",
       "jsFunction": "sorter"
     },
     {
-      "name": "autoArchiveNotes",
-      "alias": ["util:autoArchiveNotes", "util"],
-      "description": "Provides possibility to auto archive notes with a specific tag and a given lifetime (moves note to @Archive)",
-      "jsFunction": "autoArchiveNotes"
+      "name": "archiveNotes",
+      "alias": ["well:archiveNotes", "well"],
+      "description": "Provides possibility to archive notes with a specific tag and a given lifetime (moves note to @Archive)",
+      "jsFunction": "archiveNotes"
     },
     {
       "name": "cleanUpEmptyLinesInFuture",
-      "alias": ["util:cleanUpEmptyLinesInFuture", "util"],
+      "alias": ["well:cleanUpEmptyLinesInFuture", "well"],
       "description": "Remove empty lines in future daily notes",
       "jsFunction": "cleanUpEmptyLinesInFuture"
     }

--- a/m1well.Utils/src/cleanup.js
+++ b/m1well.Utils/src/cleanup.js
@@ -14,6 +14,8 @@ import {
   sortByType
 } from './utilsHelper'
 
+export const TASK_LIST_TEXT_TYPES = ['open', 'scheduled', 'cancelled', 'done', 'list', 'text']
+
 const CONFIG_KEYS = {
   archiveNotesTag: 'archiveNotesTag',
   archiveNotesLifeInDays: 'archiveNotesLifeInDays',
@@ -39,7 +41,7 @@ const EXAMPLE_CONFIG = `
  *
  * @private
  */
-const sorter = async (): Promise<boolean> => {
+const selectionSorter = async (): Promise<boolean> => {
 
   const selectedParagraphs = Editor.selectedParagraphs
 
@@ -55,11 +57,8 @@ const sorter = async (): Promise<boolean> => {
       }
     }
 
-    const selectedNonTasksAndList = selectedParagraphs.filter(para => para.type !== 'open' && para.type !== 'scheduled'
-      && para.type !== 'done' && para.type !== 'cancelled' && para.type !== 'list')
-
-    const selected = selectedParagraphs.filter(para => para.type === 'open' || para.type === 'scheduled'
-      || para.type === 'done' || para.type === 'cancelled' || para.type === 'list')
+    const selectedNonTasksAndList = selectedParagraphs.filter(para => !TASK_LIST_TEXT_TYPES.includes(para.type))
+    const selected = selectedParagraphs.filter(para => TASK_LIST_TEXT_TYPES.includes(para.type))
 
     Editor.removeParagraphs(selectedParagraphs)
 
@@ -174,4 +173,4 @@ const validateConfig = (config: Config): string | null => {
   return null
 }
 
-export { sorter, archiveNotes, cleanUpEmptyLinesInFuture }
+export { selectionSorter, archiveNotes, cleanUpEmptyLinesInFuture }

--- a/m1well.Utils/src/cleanup.js
+++ b/m1well.Utils/src/cleanup.js
@@ -1,0 +1,177 @@
+// @flow
+
+import { addDays, differenceInCalendarDays, startOfTomorrow } from 'date-fns'
+import { getOrMakeConfigurationSection } from '../../nmn.Templates/src/configuration'
+import type { Config } from './utilsHelper'
+import {
+  castNumberFromMixed,
+  castStringFromMixed,
+  futureDateFromInputOrTomorrow,
+  getDailyNote,
+  logError,
+  logMessage,
+  sortByPrio,
+  sortByType
+} from './utilsHelper'
+
+const CONFIG_KEYS = {
+  autoArchiveTag: 'autoArchiveTag',
+  autoArchiveLifeInDays: 'autoArchiveLifeInDays',
+}
+
+// if there is no config in the '_configuration' file, then provide an example config
+// currently only needed for autoArchiveNotes command
+const EXAMPLE_CONFIG = `  
+  /* >> utils plugin start <<
+   * for more information please have a look at the plugins' readme
+   */
+  utils: {
+    // just an example autoArchiveTag - please adapt to your needs
+    ${CONFIG_KEYS.autoArchiveTag}: '#scratch',
+    // here you can enter the amount of days (> 0!) of the auto archive lifetime notes
+    ${CONFIG_KEYS.autoArchiveLifeInDays}: 7,
+  },
+  /* >> utils plugin end << */
+`
+
+/**
+ * sort lines
+ *
+ * @private
+ */
+const sorter = async (): Promise<boolean> => {
+
+  const selectedParagraphs = Editor.selectedParagraphs
+
+  if (selectedParagraphs.length > 1) {
+    let firstIndex = 0
+
+    // check at least 2 paragraphs against all paragraphs and then get the first line index
+    // otherwise it gets inserted at lineIndex = 0
+    for (let i = 0; i < Editor.paragraphs.length; i++) {
+      if (Editor.paragraphs[i].rawContent === selectedParagraphs[0].rawContent
+        && Editor.paragraphs[i + 1].rawContent === selectedParagraphs[1].rawContent) {
+        firstIndex = Editor.paragraphs[i].lineIndex
+      }
+    }
+
+    const selectedNonTasksAndList = selectedParagraphs.filter(para => para.type !== 'open' && para.type !== 'scheduled'
+      && para.type !== 'done' && para.type !== 'cancelled' && para.type !== 'list')
+
+    const selected = selectedParagraphs.filter(para => para.type === 'open' || para.type === 'scheduled'
+      || para.type === 'done' || para.type === 'cancelled' || para.type === 'list')
+
+    Editor.removeParagraphs(selectedParagraphs)
+
+    selected
+      .sort(sortByType())
+      .sort(sortByPrio())
+      .forEach((para, i) => Editor.insertParagraph(para.content, firstIndex + i, para.type))
+
+    selectedNonTasksAndList
+      .forEach((para, i) => Editor.insertParagraph(para.content, firstIndex + selected.length + i, para.type))
+
+    return true
+  }
+
+  return false
+}
+
+/**
+ * archive specific notes automatically
+ *
+ * @returns {Promise<boolean>}
+ */
+const autoArchiveNotes = async (): Promise<boolean> => {
+  const config = await provideValidConfig()
+
+  DataStore.projectNotes.forEach(note => {
+    // check tag
+    if (note && note.hashtags.length > 0 && note.hashtags.includes(config.autoArchiveTag) && note.title) {
+      // check lifetime
+      if (addDays(note.createdDate, config.autoArchiveLifeInDays) <= new Date()) {
+        logMessage(`Note '${String(note.title)}' ready to archive`)
+        DataStore.moveNote(note.filename, '@Archive')
+      }
+    }
+  })
+
+  return true
+}
+
+/**
+ * clean up empty lines in future daily notes
+ *
+ * @returns {Promise<boolean>}
+ */
+const cleanUpEmptyLinesInFuture = async (): Promise<boolean> => {
+
+  const targetDate = await futureDateFromInputOrTomorrow('Future target date? (empty for tomorrow)')
+
+  let date = startOfTomorrow()
+  const diff = differenceInCalendarDays(targetDate, date)
+  for (let i = 0; i <= diff; i++) {
+    const note = getDailyNote(date)
+    if (note && note.paragraphs.length > 0) {
+      for (let j = 0; j < note.paragraphs.length; j++) {
+        if (note.paragraphs[j].rawContent === '') {
+          note.removeParagraph(note.paragraphs[j])
+        }
+      }
+    }
+    date = addDays(date, 1)
+  }
+
+  return true
+}
+
+/**
+ * provide config from _configuration and cast content to real objects
+ *
+ * @private
+ */
+const provideValidConfig = (): Promise<Config> => {
+  const emptyConfig = {
+    autoArchiveTag: '',
+    autoArchiveLifeInDays: 0,
+  }
+  return getOrMakeConfigurationSection(
+    'utils',
+    EXAMPLE_CONFIG
+  )
+    .then(result => {
+      if (result == null || Object.keys(result).length === 0) {
+        logError('expected config could not be found in the _configuration file')
+        return emptyConfig
+      } else {
+        logMessage(`loaded config\n${JSON.stringify(result)}\n`)
+        const config: Config = {
+          autoArchiveTag: castStringFromMixed(result, CONFIG_KEYS.autoArchiveTag),
+          autoArchiveLifeInDays: castNumberFromMixed(result, CONFIG_KEYS.autoArchiveLifeInDays),
+        }
+        const validate = validateConfig(config)
+        if (validate) {
+          logError(validate)
+          return emptyConfig
+        }
+        return config
+      }
+    })
+}
+
+/**
+ * validade the config
+ *
+ * @private
+ */
+const validateConfig = (config: Config): string | null => {
+  if (!config.autoArchiveTag.startsWith('#') || config.autoArchiveTag.length < 2) {
+    return `autoArchiveTag has no '#' or is too short`
+  }
+  if (config.autoArchiveLifeInDays < 1) {
+    return 'autoArchiveLifeInDays is too small'
+  }
+  return null
+}
+
+export { sorter, autoArchiveNotes, cleanUpEmptyLinesInFuture }

--- a/m1well.Utils/src/cleanup.js
+++ b/m1well.Utils/src/cleanup.js
@@ -15,8 +15,8 @@ import {
 } from './utilsHelper'
 
 const CONFIG_KEYS = {
-  autoArchiveTag: 'autoArchiveTag',
-  autoArchiveLifeInDays: 'autoArchiveLifeInDays',
+  archiveNotesTag: 'archiveNotesTag',
+  archiveNotesLifeInDays: 'archiveNotesLifeInDays',
 }
 
 // if there is no config in the '_configuration' file, then provide an example config
@@ -26,10 +26,10 @@ const EXAMPLE_CONFIG = `
    * for more information please have a look at the plugins' readme
    */
   utils: {
-    // just an example autoArchiveTag - please adapt to your needs
-    ${CONFIG_KEYS.autoArchiveTag}: '#scratch',
-    // here you can enter the amount of days (> 0!) of the auto archive lifetime notes
-    ${CONFIG_KEYS.autoArchiveLifeInDays}: 7,
+    // just an example archiveNotesTag - please adapt to your needs
+    ${CONFIG_KEYS.archiveNotesTag}: '#scratch',
+    // here you can enter the amount of days (> 0!) of the archive lifetime notes
+    ${CONFIG_KEYS.archiveNotesLifeInDays}: 7,
   },
   /* >> utils plugin end << */
 `
@@ -78,18 +78,18 @@ const sorter = async (): Promise<boolean> => {
 }
 
 /**
- * archive specific notes automatically
+ * archive specific notes
  *
  * @returns {Promise<boolean>}
  */
-const autoArchiveNotes = async (): Promise<boolean> => {
+const archiveNotes = async (): Promise<boolean> => {
   const config = await provideValidConfig()
 
   DataStore.projectNotes.forEach(note => {
     // check tag
-    if (note && note.hashtags.length > 0 && note.hashtags.includes(config.autoArchiveTag) && note.title) {
+    if (note && note.hashtags.length > 0 && note.hashtags.includes(config.archiveNotesTag) && note.title) {
       // check lifetime
-      if (addDays(note.createdDate, config.autoArchiveLifeInDays) <= new Date()) {
+      if (addDays(note.createdDate, config.archiveNotesLifeInDays) <= new Date()) {
         logMessage(`Note '${String(note.title)}' ready to archive`)
         DataStore.moveNote(note.filename, '@Archive')
       }
@@ -132,8 +132,8 @@ const cleanUpEmptyLinesInFuture = async (): Promise<boolean> => {
  */
 const provideValidConfig = (): Promise<Config> => {
   const emptyConfig = {
-    autoArchiveTag: '',
-    autoArchiveLifeInDays: 0,
+    archiveNotesTag: '',
+    archiveNotesLifeInDays: 0,
   }
   return getOrMakeConfigurationSection(
     'utils',
@@ -146,8 +146,8 @@ const provideValidConfig = (): Promise<Config> => {
       } else {
         logMessage(`loaded config\n${JSON.stringify(result)}\n`)
         const config: Config = {
-          autoArchiveTag: castStringFromMixed(result, CONFIG_KEYS.autoArchiveTag),
-          autoArchiveLifeInDays: castNumberFromMixed(result, CONFIG_KEYS.autoArchiveLifeInDays),
+          archiveNotesTag: castStringFromMixed(result, CONFIG_KEYS.archiveNotesTag),
+          archiveNotesLifeInDays: castNumberFromMixed(result, CONFIG_KEYS.archiveNotesLifeInDays),
         }
         const validate = validateConfig(config)
         if (validate) {
@@ -165,13 +165,13 @@ const provideValidConfig = (): Promise<Config> => {
  * @private
  */
 const validateConfig = (config: Config): string | null => {
-  if (!config.autoArchiveTag.startsWith('#') || config.autoArchiveTag.length < 2) {
-    return `autoArchiveTag has no '#' or is too short`
+  if (!config.archiveNotesTag.startsWith('#') || config.archiveNotesTag.length < 2) {
+    return `archiveNotesTag has no '#' or is too short`
   }
-  if (config.autoArchiveLifeInDays < 1) {
-    return 'autoArchiveLifeInDays is too small'
+  if (config.archiveNotesLifeInDays < 1) {
+    return 'archiveNotesLifeInDays is too small'
   }
   return null
 }
 
-export { sorter, autoArchiveNotes, cleanUpEmptyLinesInFuture }
+export { sorter, archiveNotes, cleanUpEmptyLinesInFuture }

--- a/m1well.Utils/src/index.js
+++ b/m1well.Utils/src/index.js
@@ -7,4 +7,4 @@
 // -----------------------------------------------------------------------------
 
 export { repeater } from './repeater'
-export { sorter, archiveNotes, cleanUpEmptyLinesInFuture } from './cleanup'
+export { selectionSorter, archiveNotes, cleanUpEmptyLinesInFuture } from './cleanup'

--- a/m1well.Utils/src/index.js
+++ b/m1well.Utils/src/index.js
@@ -7,4 +7,4 @@
 // -----------------------------------------------------------------------------
 
 export { repeater } from './repeater'
-export { sorter, autoArchiveNotes, cleanUpEmptyLinesInFuture } from './cleanup'
+export { sorter, archiveNotes, cleanUpEmptyLinesInFuture } from './cleanup'

--- a/m1well.Utils/src/index.js
+++ b/m1well.Utils/src/index.js
@@ -1,0 +1,10 @@
+// @flow
+
+// -----------------------------------------------------------------------------
+// Plugin for some Utils like repeat selected task, etc.
+// Michael Wellner (@m1well)
+// v1.0.0, 05.01.2022
+// -----------------------------------------------------------------------------
+
+export { repeater } from './repeater'
+export { sorter, autoArchiveNotes, cleanUpEmptyLinesInFuture } from './cleanup'

--- a/m1well.Utils/src/repeater.js
+++ b/m1well.Utils/src/repeater.js
@@ -1,0 +1,266 @@
+// @flow
+
+import {
+  addDays,
+  addMonths,
+  addYears,
+  getDay,
+  getDaysInMonth,
+  getMonth,
+  getYear,
+  nextFriday,
+  nextMonday,
+  nextSaturday,
+  nextSunday,
+  nextThursday,
+  nextTuesday,
+  nextWednesday,
+  setDate
+} from 'date-fns'
+import { inputInteger } from '../../helpers/userInput'
+import { futureDateFromInputOrTomorrow, getDailyNote } from './utilsHelper'
+
+/**
+ * creates repetitions for selected lines
+ *
+ * @returns {Promise<boolean>}
+ */
+const repeater = async (): Promise<boolean> => {
+
+  const currentOpenNote = Editor.note
+  const selectedOpenTasks = Editor.selectedParagraphs
+    .filter(para => (para.type === 'open' || para.type === 'list'))
+    .map(para => para.content)
+
+  const startDate = await futureDateFromInputOrTomorrow('Future start date? (empty for tomorrow)')
+  const unit = await CommandBar.showOptions([ 'Day', 'Week', '2 Weeks', 'Month', '2 Months',
+    'Quarter-year', 'Half-year', 'Year', 'Special' ], 'Select unit (every ...)')
+
+  if (unit.value === 'Special') {
+    const special = await CommandBar.showOptions([ 'Every special weekday (e.g. \'every Monday\')',
+      'Every nth day of month' ], 'Select a special')
+
+    if (special.index === 0) {
+      await everySpecialWeekdayRepetition(selectedOpenTasks, startDate)
+      if (currentOpenNote) {
+        await Editor.openNoteByFilename(currentOpenNote.filename)
+      }
+      return true
+    }
+    if (special.index === 1) {
+      await everySpecialDayInMonthRepetition(selectedOpenTasks, startDate)
+      if (currentOpenNote) {
+        await Editor.openNoteByFilename(currentOpenNote.filename)
+      }
+      return true
+    }
+
+  } else {
+    // no special
+    await standardRepetition(selectedOpenTasks, startDate, unit.value)
+    if (currentOpenNote) {
+      await Editor.openNoteByFilename(currentOpenNote.filename)
+    }
+    return true
+  }
+
+  return false
+}
+
+/**
+ * standard repetition - every ...
+ *
+ * @private
+ */
+const standardRepetition = async (selectedOpenTasks: string[], startDate: Date, unit: string): Promise<boolean> => {
+  const reps = await inputInteger('Select repetitions (incl. first one)')
+
+  let actionDate = startDate
+  for (let i = 1; i <= reps; i++) {
+    const note = getDailyNote(actionDate)
+    selectedOpenTasks.forEach(task => {
+      if (note) {
+        insertRepeatParagraph(note, task, reps, i)
+      }
+    })
+    switch (unit) {
+      case 'Year':
+        actionDate = addYears(actionDate, 1)
+        break
+      case 'Half-year':
+        actionDate = addMonths(actionDate, 6)
+        break
+      case 'Quarter-year':
+        actionDate = addMonths(actionDate, 3)
+        break
+      case '2 Months':
+        actionDate = addMonths(actionDate, 2)
+        break
+      case 'Month':
+        actionDate = addMonths(actionDate, 1)
+        break
+      case '2 Weeks':
+        actionDate = addDays(actionDate, 14)
+        break
+      case 'Week':
+        actionDate = addDays(actionDate, 7)
+        break
+      default:
+        actionDate = addDays(actionDate, 1)
+        break
+    }
+  }
+  return true
+}
+
+/**
+ * special repetition for "every weekday"
+ *
+ * @private
+ */
+const everySpecialWeekdayRepetition = async (selectedOpenTasks: string[], startDate: Date): Promise<boolean> => {
+  const weekday = await CommandBar.showOptions([ 'Monday', 'Tuesday', 'Wednesday', 'Thursday',
+    'Friday', 'Saturday', 'Sunday' ], 'Select weekday')
+  const reps = await inputInteger('Select repetitions (incl. first one)')
+
+  let actionDate
+  switch (weekday.index) {
+    case 0:
+      actionDate = nextMonday(startDate)
+      break
+    case 1:
+      actionDate = nextTuesday(startDate)
+      break
+    case 2:
+      actionDate = nextWednesday(startDate)
+      break
+    case 3:
+      actionDate = nextThursday(startDate)
+      break
+    case 4:
+      actionDate = nextFriday(startDate)
+      break
+    case 5:
+      actionDate = nextSaturday(startDate)
+      break
+    case 6:
+      actionDate = nextSunday(startDate)
+      break
+    default:
+      actionDate = startDate
+  }
+
+  for (let i = 1; i <= reps; i++) {
+    const note = getDailyNote(actionDate)
+    selectedOpenTasks.forEach(task => {
+      if (note) {
+        insertRepeatParagraph(note, task, reps, i)
+      }
+    })
+    actionDate = addDays(actionDate, 7)
+  }
+  return true
+}
+
+/**
+ * special repetition for "nth day in month"
+ *
+ * @private
+ */
+const everySpecialDayInMonthRepetition = async (selectedOpenTasks: string[], startDate: Date): Promise<boolean> => {
+  const dayInMonth = await CommandBar.showOptions([ 'First', 'Second', 'Third', '5.', '10.', '15.', '20.',
+    '25.', 'penultimate', 'last' ], 'Select day in month')
+  const reps = await inputInteger('Select repetitions (incl. first one)')
+
+  let actionDate = startDate
+  for (let i = 1; i <= reps; i++) {
+    const year = getYear(actionDate)
+    const month = getMonth(actionDate)
+    switch (dayInMonth.index) {
+      case 0:
+        actionDate = dayInMonthActionDate(actionDate, year, month, 1)
+        break
+      case 1:
+        actionDate = dayInMonthActionDate(actionDate, year, month, 2)
+        break
+      case 2:
+        actionDate = dayInMonthActionDate(actionDate, year, month, 3)
+        break
+      case 3:
+        actionDate = dayInMonthActionDate(actionDate, year, month, 5)
+        break
+      case 4:
+        actionDate = dayInMonthActionDate(actionDate, year, month, 10)
+        break
+      case 5:
+        actionDate = dayInMonthActionDate(actionDate, year, month, 15)
+        break
+      case 6:
+        actionDate = dayInMonthActionDate(actionDate, year, month, 20)
+        break
+      case 7:
+        actionDate = dayInMonthActionDate(actionDate, year, month, 25)
+        break
+      case 8:
+        actionDate = dayInMonthActionDate(actionDate, year, month, -10)
+        break
+      case 9:
+        actionDate = dayInMonthActionDate(actionDate, year, month, -100)
+        break
+    }
+
+    const note = getDailyNote(actionDate)
+    selectedOpenTasks.forEach(task => {
+      if (note) {
+        insertRepeatParagraph(note, task, reps, i)
+      }
+    })
+    actionDate = setDate(addMonths(actionDate, 1), 1)
+  }
+
+  return true
+}
+
+/**
+ * get the new action date of the month (-10 for "penultimate" and -100 for "last")
+ *
+ * @private
+ */
+const dayInMonthActionDate = (checkDate: Date, year: number, month: number, day: number): Date => {
+  if (day === -10) {
+    if (getDay(checkDate) <= getDaysInMonth(checkDate) - 1) {
+      return new Date(year, month, getDaysInMonth(checkDate) - 1)
+    } else {
+      const withNewMonth = addMonths(checkDate, 1)
+      return setDate(withNewMonth, getDaysInMonth(checkDate) - 1)
+    }
+  }
+  if (day === -100) {
+    if (getDay(checkDate) <= getDaysInMonth(checkDate)) {
+      return new Date(year, month, getDaysInMonth(checkDate))
+    } else {
+      const withNewMonth = addMonths(checkDate, 1)
+      return setDate(withNewMonth, getDaysInMonth(checkDate))
+    }
+  }
+  if (getDay(checkDate) <= day - 1) {
+    return new Date(year, month, day)
+  } else {
+    return setDate(addMonths(checkDate, 1), day)
+  }
+}
+
+/**
+ * inserts the repeat paragraph - the numbers of the last one are **bold**
+ *
+ * @private
+ */
+const insertRepeatParagraph = (note: TNote, task: string, reps: number, i: number) => {
+  if (i === reps) {
+    note.insertParagraph(`${task} @repeat(**!!${i}/${String(reps)}!!**)`, 0, 'open')
+  } else {
+    note.insertParagraph(`${task} @repeat(${i}/${String(reps)})`, 0, 'open')
+  }
+}
+
+export { repeater }

--- a/m1well.Utils/src/utilsHelper.js
+++ b/m1well.Utils/src/utilsHelper.js
@@ -6,8 +6,8 @@ import { showMessage } from '../../helpers/userInput'
 const DATE_FORMAT_ISO = 'yyyy-MM-dd'
 
 export type Config = {
-  autoArchiveTag: string,
-  autoArchiveLifeInDays: number,
+  archiveNotesTag: string,
+  archiveNotesLifeInDays: number,
 }
 
 /**
@@ -89,10 +89,10 @@ export const sortByType = (): Function => {
     } else {
       // then handle all tasks
       if (first.type === 'done') {
-        return 1
+        return second.type === 'list' ? 1 : -1
       }
       if (second.type === 'done') {
-        return -1
+        return first.type === 'list' ? -1 : 1
       }
       if (first.type === 'cancelled') {
         return -1
@@ -137,7 +137,7 @@ export const logError = async (msg: string): Promise<void> => {
 
 /**
  * find property with key in mixed object
- * 
+ *
  * @private
  */
 const findPropertyInMixed = (val: { [string]: ?mixed }, key: string): any | null => {

--- a/m1well.Utils/src/utilsHelper.js
+++ b/m1well.Utils/src/utilsHelper.js
@@ -1,0 +1,202 @@
+// @flow
+
+import { isFuture, isMatch, parse, startOfTomorrow } from 'date-fns'
+import { showMessage } from '../../helpers/userInput'
+
+const DATE_FORMAT_ISO = 'yyyy-MM-dd'
+
+export type Config = {
+  autoArchiveTag: string,
+  autoArchiveLifeInDays: number,
+}
+
+/**
+ * cast string from the config mixed
+ *
+ * @param val the config mixed
+ * @param key name of the property you want to cast
+ * @returns {string} casted value
+ */
+export const castStringFromMixed = (val: { [string]: ?mixed }, key: string): string => {
+  const result = findPropertyInMixed(val, key)
+  return result ? ((result: any): string) : ''
+}
+
+/**
+ * cast number from the config mixed
+ *
+ * @param val the config mixed
+ * @param key name of the property you want to cast
+ * @returns {string} casted value
+ */
+export const castNumberFromMixed = (val: { [string]: ?mixed }, key: string): number => {
+  const result = findPropertyInMixed(val, key)
+  return result ? ((result: any): number) : 0
+}
+
+/**
+ * Currently there is no function to create a daily note in the future, if it doesn't exist
+ * Hopefully this is coming very soon - then add this here to this function
+ *
+ * @param day future date
+ * @returns {?TNote} note if it exists
+ */
+export const getDailyNote = (day: Date): ?TNote => {
+  return DataStore.calendarNoteByDate(day)
+}
+
+/**
+ * sort function for paragraphs by prio `!!!`, `!!` and `!`
+ *
+ * @returns {(function(TParagraph, TParagraph): (number))}
+ */
+export const sortByPrio = (): Function => {
+  return (second: TParagraph, first: TParagraph) => {
+    if (haveSameTypes(first, second)) {
+      if (isFlaggedThrice(first) || isFlaggedThrice(second)) {
+        return isFlaggedThrice(first) ? 1 : -1
+      }
+      if (isFlaggedTwice(first)) {
+        return isFlaggedThrice(second) ? -1 : 1
+      }
+      if (isFlaggedTwice(second)) {
+        return isFlaggedThrice(first) ? 1 : -1
+      }
+      if (isFlaggedOnce(first)) {
+        return (isFlaggedTwice(second) || isFlaggedThrice(second)) ? -1 : 1
+      }
+      if (isFlaggedOnce(second)) {
+        return (isFlaggedTwice(second) || isFlaggedThrice(first)) ? 1 : -1
+      }
+    }
+    return 0
+  }
+}
+
+/**
+ * sort by type (open, scheduled, cancelled, done, list, text) by it's type
+ *
+ * @returns {(function(TParagraph, TParagraph): (number))} sorted paragraphs
+ */
+export const sortByType = (): Function => {
+  return (second: TParagraph, first: TParagraph) => {
+    if (first.type === 'text' || second.type === 'text') {
+      // handle text first
+      return first.type === 'text' ? -1 : 1
+    } else if (first.type === 'list' || second.type === 'list') {
+      // handle list second
+      return first.type === 'list' ? -1 : 1
+    } else {
+      // then handle all tasks
+      if (first.type === 'done') {
+        return 1
+      }
+      if (second.type === 'done') {
+        return -1
+      }
+      if (first.type === 'cancelled') {
+        return -1
+      }
+      if (second.type === 'cancelled') {
+        return 1
+      }
+      if (first.type === 'scheduled') {
+        return second.type === 'open' ? -1 : 1
+      }
+      if (second.type === 'scheduled') {
+        return first.type === 'open' ? 1 : -1
+      }
+    }
+    return 0
+  }
+}
+
+/**
+ * get future date from user input or return tomorrow
+ *
+ * @param question question to ask user
+ * @returns {Promise<Date>} the input date or tomorrow
+ */
+export const futureDateFromInputOrTomorrow = async (question: string): Promise<Date> => {
+  let input = '-'
+
+  while (input && !checkIsFutureDateWithFormat(input, DATE_FORMAT_ISO)) {
+    input = await CommandBar.showInput(question, 'Enter future date')
+  }
+  return input ? parse(input, DATE_FORMAT_ISO, new Date()) : startOfTomorrow()
+}
+
+export const logMessage = (msg: string): void => {
+  console.log(`\tutils log: ${msg}`)
+}
+
+export const logError = async (msg: string): Promise<void> => {
+  console.log(`\tutils error: ${msg}`)
+  await showMessage(`ERROR: ${msg}`)
+}
+
+/**
+ * find property with key in mixed object
+ * 
+ * @private
+ */
+const findPropertyInMixed = (val: { [string]: ?mixed }, key: string): any | null => {
+  let foundProperty = val
+  const properties = key.split('.')
+
+  for (let i = 0; i < properties.length; i++) {
+    const prop = properties[i]
+    if (!foundProperty || !foundProperty.hasOwnProperty(prop)) {
+      return null
+    } else {
+      foundProperty = foundProperty[prop]
+    }
+  }
+  return foundProperty
+}
+
+/**
+ * check if paragrphs have same type
+ *
+ * @private
+ */
+const haveSameTypes = (paragraphOne: TParagraph, paragraphTwo: TParagraph): boolean => {
+  return paragraphOne.type === paragraphTwo.type
+}
+
+/**
+ * check if paragraph is flagged thrice
+ *
+ * @private
+ */
+const isFlaggedThrice = (paragraph: TParagraph): boolean => {
+  return paragraph.content.startsWith('!!!')
+}
+
+/**
+ * check if paragraph is flagged twice
+ *
+ * @private
+ */
+const isFlaggedTwice = (paragraph: TParagraph): boolean => {
+  return paragraph.content.startsWith('!!')
+}
+
+/**
+ * check if paragraph is flagged once
+ *
+ * @private
+ */
+const isFlaggedOnce = (paragraph: TParagraph): boolean => {
+  return paragraph.content.startsWith('!')
+}
+
+/**
+ * check if date has given format and is in the future
+ *
+ * @private
+ */
+const checkIsFutureDateWithFormat = (dateStr: string, format: string): boolean => {
+  return isMatch(dateStr, format) && isFuture(parse(dateStr, format, new Date()))
+}
+


### PR DESCRIPTION
PR because of this requirement to automatically archive specific notes `using-noteplan` channel.
i had something similar and collected now some of my useful functions I currently use nearly daily.

please read the README, this is too much for here :D
in short:
- `repeater` - repeat functionality with many possibilities and just by selecting any line(s) in every note you want
- `sorter` - sort lines by type (open, scheduled, cancelled, done, list, text) and prio (`!!!`, `!!`, `!`)
- `autoArchiver` - archive notes with a specific hashtag and a specific lifetime
- `cleanUpEmptyLinesInFuture` - just clean up empty lines in future daily notes 