### PR TITLE
expenses plugin - notes via datastore

### DIFF
--- a/m1well.Expenses/CHANGELOG.md
+++ b/m1well.Expenses/CHANGELOG.md
@@ -1,5 +1,9 @@
 # m1well.Expenses Plugin Changelog
 
+## [1.6.0] - 2022-01-05 (@m1well)
+### Changed
+- Load tracking notes via DataStore to not open them all the time
+
 ## [1.5.1] - 2022-01-04 (@m1well)
 ### Fixed
 - corrected [plugin.json](./plugin.json) according to the official documentation  

--- a/m1well.Expenses/plugin.json
+++ b/m1well.Expenses/plugin.json
@@ -7,7 +7,7 @@
   "plugin.description": "Plugin to track your expenses for further analyis",
   "plugin.author": "@m1well",
   "plugin.url": "https://github.com/NotePlan/plugins/blob/main/m1well.Expenses/README.md",
-  "plugin.version": "1.5.1",
+  "plugin.version": "1.6.0",
   "plugin.dependencies": [],
   "plugin.script": "script.js",
   "plugin.commands": [

--- a/m1well.Expenses/src/expenses.js
+++ b/m1well.Expenses/src/expenses.js
@@ -118,7 +118,7 @@ const EXAMPLE_CONFIG = `
 `
 
 /**
- * @description expenses tracking with three possibilities (individual, shortcuts, fixed)
+ * expenses tracking with three possibilities (individual, shortcuts, fixed)
  *
  * @returns {Promise<boolean>}
  */
@@ -138,7 +138,7 @@ const expensesTracking = async (): Promise<boolean> => {
 }
 
 /**
- * @description aggregates expenses of given year to a new note
+ * aggregates expenses of given year to a new note
  *
  * @returns {Promise<boolean>}
  */
@@ -157,8 +157,7 @@ const expensesAggregate = async (): Promise<boolean> => {
     return false
   }
 
-  await Editor.openNoteByTitle(noteTitleTracking)
-  const trackingNote = Editor.note
+  const trackingNote = DataStore.projectNoteByTitle(noteTitleTracking)?.[0]
 
   if (trackingNote) {
     const trackedData = trackingNote.paragraphs
@@ -199,7 +198,7 @@ const expensesAggregate = async (): Promise<boolean> => {
 }
 
 /**
- * @description tracking of individual expenses
+ * tracking of individual expenses
  *
  * @returns {Promise<boolean>}
  */
@@ -235,8 +234,7 @@ const individualTracking = async (): Promise<boolean> => {
     return false
   }
 
-  await Editor.openNoteByTitle(title)
-  const note = Editor.note
+  const note = DataStore.projectNoteByTitle(title)?.[0]
   const expenseRow = {
     date: currentDate,
     category: category.value,
@@ -245,13 +243,14 @@ const individualTracking = async (): Promise<boolean> => {
   }
   if (note) {
     note.appendParagraph(createTrackingExpenseRowWithConfig(expenseRow, config), 'text')
+    await CommandBar.showOptions([ 'OK' ], 'Individual Expenses saved')
   }
 
   return true
 }
 
 /**
- * @description tracking of shortcut expenses
+ * tracking of shortcut expenses
  *
  * @returns {Promise<boolean>}
  */
@@ -296,8 +295,7 @@ const shortcutsTracking = async (): Promise<boolean> => {
     return false
   }
 
-  await Editor.openNoteByTitle(title)
-  const note = Editor.note
+  const note = DataStore.projectNoteByTitle(title)?.[0]
   const expenseRow = {
     date: currentDate,
     category: selected.category,
@@ -306,13 +304,14 @@ const shortcutsTracking = async (): Promise<boolean> => {
   }
   if (note) {
     note.appendParagraph(createTrackingExpenseRowWithConfig(expenseRow, config), 'text')
+    await CommandBar.showOptions([ 'OK' ], 'Shortcut Expenses saved')
   }
 
   return true
 }
 
 /**
- * @description tracking of fixed expenses
+ * tracking of fixed expenses
  *
  * @returns {Promise<boolean>}
  */
@@ -335,8 +334,7 @@ const fixedTracking = async (): Promise<boolean> => {
 
   const lines: string[] = []
 
-  await Editor.openNoteByTitle(title)
-  const note = Editor.note
+  const note = DataStore.projectNoteByTitle(title)?.[0]
   config.fixedExpenses
     .filter(exp => exp.active && (exp.month === 0 || exp.month === month))
     .map(exp => {
@@ -357,13 +355,14 @@ const fixedTracking = async (): Promise<boolean> => {
 
   if (note) {
     note.appendParagraph(lines.join('\n'), 'text')
+    await CommandBar.showOptions([ 'OK' ], 'Fixed Expenses saved')
   }
 
   return true
 }
 
 /**
- * @description provide config from _configuration and cast content to real objects
+ * provide config from _configuration and cast content to real objects
  *
  * @private
  */
@@ -403,7 +402,7 @@ const provideConfig = (): Promise<Config> => {
 }
 
 /**
- * @description check if one note exists by name, if mulitple exists - throw error, of none extist -> create it
+ * check if one note exists by name, if mulitple exists - throw error, of none extist -> create it
  *
  * @private
  */
@@ -440,7 +439,7 @@ const provideAndCheckNote = async (title: string,
 }
 
 /**
- * @description check data quality of tracked data before we aggregate it
+ * check data quality of tracked data before we aggregate it
  *
  * @private
  */

--- a/m1well.Expenses/src/expensesChecks.js
+++ b/m1well.Expenses/src/expensesChecks.js
@@ -10,7 +10,7 @@ const MINIMAL_COLUMNS = [ 'date', 'category', 'amount' ]
 const ALLOWED_AMOUNT_FORMATS = [ 'full', 'short' ]
 
 /**
- * @description check if the amount is smaller than 1_000_000 and greater than -1_000_000 and is not 0 or null or NaN
+ * check if the amount is smaller than 1_000_000 and greater than -1_000_000 and is not 0 or null or NaN
  *
  * @param amount amount from user input
  * @returns {boolean} true/false
@@ -20,7 +20,7 @@ export const amountOk = (amount: number): boolean => {
 }
 
 /**
- * @description check if the category is in the array in the configuration
+ * check if the category is in the array in the configuration
  *
  * @param category category from user input
  * @param categories categories from config
@@ -31,7 +31,7 @@ export const categoryOk = (category: string, categories: string[]): boolean => {
 }
 
 /**
- * @description just do some checks on the privided config and e.g. add a default delimiter if none is set
+ * just do some checks on the privided config and e.g. add a default delimiter if none is set
  *
  * @param config casted config from _configuration
  * @param currentDate current date - example of date to check if configured date format is valid

--- a/m1well.Expenses/src/expensesHelper.js
+++ b/m1well.Expenses/src/expensesHelper.js
@@ -10,7 +10,7 @@ const fullAmountConfig = {
 }
 
 /**
- * @description cast string from the config mixed
+ * cast string from the config mixed
  *
  * @param val the config mixed
  * @param key name of the property you want to cast
@@ -21,7 +21,7 @@ export const castStringFromMixed = (val: { [string]: ?mixed }, key: string): str
 }
 
 /**
- * @description cast string array from the config mixed
+ * cast string array from the config mixed
  *
  * @param val the config mixed
  * @param key name of the property you want to cast
@@ -32,7 +32,7 @@ export const castStringArrayFromMixed = (val: { [string]: ?mixed }, key: string)
 }
 
 /**
- * @description cast ShortcutExpenses array from the config mixed
+ * cast ShortcutExpenses array from the config mixed
  *
  * @param val the config mixed
  * @param key name of the property you want to cast
@@ -43,7 +43,7 @@ export const castShortcutExpensesArrayFromMixed = (val: { [string]: ?mixed }, ke
 }
 
 /**
- * @description cast FixedExpenses array from the config mixed
+ * cast FixedExpenses array from the config mixed
  *
  * @param val the config mixed
  * @param key name of the property you want to cast
@@ -54,7 +54,7 @@ export const castFixedExpensesArrayFromMixed = (val: { [string]: ?mixed }, key: 
 }
 
 /**
- * @description extract a expense row from the string of the tracking note
+ * extract a expense row from the string of the tracking note
  *
  * @param row string value from the tracking note
  * @param config the config
@@ -92,7 +92,7 @@ export const extractExpenseRowFromCsvRow = (row: string, config: Config): Expens
 }
 
 /**
- * @description aggregates a tracking note by categories and month
+ * aggregates a tracking note by categories and month
  *
  * @param values rows from the tracking note
  * @param delimiter configured delimiter
@@ -118,7 +118,7 @@ export const aggregateByCategoriesAndMonth = (values: ExpenseTrackingRow[],
 }
 
 /**
- * @description create new string tracking row with some configured properties (e.g. delimiter)
+ * create new string tracking row with some configured properties (e.g. delimiter)
  *
  * @param row row from the user input
  * @param config the config
@@ -143,7 +143,7 @@ export const createTrackingExpenseRowWithConfig = (row: ExpenseTrackingRow, conf
 }
 
 /**
- * @description create new string aggregated row with delimiter
+ * create new string aggregated row with delimiter
  *
  * @param row row from the aggregated function
  * @param config the config
@@ -165,7 +165,7 @@ export const createAggregationExpenseRowWithDelimiter = (row: ExpenseAggregateRo
 }
 
 /**
- * @description stringify the objects from the shortcut list to show them as input options
+ * stringify the objects from the shortcut list to show them as input options
  *
  * @param shortcuts shortcuts from the config
  * @param delimiter delimiter for the shortcuts
@@ -182,7 +182,7 @@ export const stringifyShortcutList = (shortcuts: ShortcutExpense[], delimiter: s
 }
 
 /**
- * @description here you can left pad your number with zeros - e.g. a '5' with 3 targetDigits is getting a '005'
+ * here you can left pad your number with zeros - e.g. a '5' with 3 targetDigits is getting a '005'
  *
  * @param current the current number
  * @param targetDigits how many digits should the target number have

--- a/m1well.Expenses/src/index.js
+++ b/m1well.Expenses/src/index.js
@@ -3,7 +3,7 @@
 // -----------------------------------------------------------------------------
 // Plugin to store your expenses for further analyis
 // Michael Wellner (@m1well)
-// v1.5.1, 04.01.2022
+// v1.6.0, 2022-01-05
 // -----------------------------------------------------------------------------
 
 export { expensesTracking, expensesAggregate, individualTracking, shortcutsTracking, fixedTracking } from './expenses'


### PR DESCRIPTION
* my "# 1 expenses plugin user" @dwertheimer had the idea that the tracking notes should not open every time after tracking
* so I changed it to call the datastore instead 
* Also deleted my `@description` in the jsdoc - don't know how I could have forget them