### PR TITLE
Add commands to launch URLs in note open tasks

### DIFF
--- a/jgclark.NoteHelpers/CHANGELOG.md
+++ b/jgclark.NoteHelpers/CHANGELOG.md
@@ -1,6 +1,12 @@
 # What's changed in 📙 Note Helpers plugin?
 For more details see the [plugin's README](https://github.com/NotePlan/plugins/tree/main/jgclark.NoteHelpers/).
 
+## [0.17.0] - 2022-06-26 @dwertheimer
+
+### Added
+- Add new command  `/open todo links in browser`
+
+
 ## [0.16.0] - 2022-06-26
 ### Updated
 - The function `jumpToHeading` (which is used for jumping to headings within the same note) can Now be used via `x-callback-url` by passing the text of the heading in as an argument

--- a/jgclark.NoteHelpers/README.md
+++ b/jgclark.NoteHelpers/README.md
@@ -11,6 +11,7 @@ This plugin provides these commands to help jump quickly between NotePlan notes,
 - **/convert to frontmatter**: convert the current note to use frontmatter syntax, including optional default text that can be added in the Plugin's settings.
 - **/add number of days to dates**: looks for bullets in your current open note that end with `[[YYYY-MM-DD]]:` and adds the number of days to or since that date. Useful for making lists of important days and easily knowing number of days to (or since) that day.
 - **/enable heading links**: converts Local links to headings (they start with the `#` character) to `x-callback-url` links that makes them work the way you expect them to. *NOTE*: They currently only support links to headings within the same note.
+- **/open todo links in browser**: find all open todos in the Editor with URLs and open any URLs in a browser (useful if you have JIRA tasks or other TODOs where you need to reference external items)
 
 ## History
 See [CHANGELOG](CHANGELOG.md) for the plugin's history.

--- a/jgclark.NoteHelpers/plugin.json
+++ b/jgclark.NoteHelpers/plugin.json
@@ -128,6 +128,21 @@
       ],
       "description": "Look for Links to headings and make them work by converting them to plugin command calls",
       "jsFunction": "convertLocalLinksToPluginLinks"
+    },
+    {
+      "name": "open todo links in browser",
+      "alias": [
+      ],
+      "description": "Open links in open todo items on the page",
+      "jsFunction": "openIncompleteLinksInNote"
+    },
+    {
+      "name": "open URL on this line",
+      "alias": [
+        "openurl","launch"
+      ],
+      "description": "Open the URL on the current line in the default browser",
+      "jsFunction": "openURLOnLine"
     }
   ],
   "plugin.settings": [

--- a/jgclark.NoteHelpers/src/NPOpenLinks.js
+++ b/jgclark.NoteHelpers/src/NPOpenLinks.js
@@ -6,7 +6,8 @@ import { getParagraphContainingPosition } from '@helpers/NPParagraph'
 /**
  * Find URLs in an array of paragraphs
  * @param {Array<TParagraph>} paras
- * @returns
+ * @author @dwertheimer
+ * @returns {Array<string>} - the URL strings as an array
  */
 export function findURLs(paras: Array<TParagraph>): Array<string> {
   const reURL = /(http|ftp|https):\/\/([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:\/~+#-]*[\w@?^=%&\/~+#-])/gim
@@ -23,6 +24,7 @@ export function findURLs(paras: Array<TParagraph>): Array<string> {
 /**
  * Find Links in Paragraphs Array and open in Browser
  * @param {*} paras
+ * @author @dwertheimer
  */
 export function openLinksInNote(paras: Array<TParagraph>) {
   const urls = findURLs(paras)
@@ -34,6 +36,7 @@ export function openLinksInNote(paras: Array<TParagraph>) {
 /**
  * Open URLs in Editor note which are OPEN todos
  * (Entrypoint for "/open todo links in browser" command)
+ * @author @dwertheimer
  */
 // eslint-disable-next-line require-await
 export async function openIncompleteLinksInNote() {
@@ -46,6 +49,7 @@ export async function openIncompleteLinksInNote() {
 /**
  * Open URLs on selected line
  * (Entrypoint for" /open URL on this line" command)
+ * @author @dwertheimer
  */
 // eslint-disable-next-line require-await
 export async function openURLOnLine() {

--- a/jgclark.NoteHelpers/src/NPOpenLinks.js
+++ b/jgclark.NoteHelpers/src/NPOpenLinks.js
@@ -1,0 +1,56 @@
+// @flow
+
+// import { log, logError, JSP, clo } from '@helpers/dev'
+import { getParagraphContainingPosition } from '@helpers/NPParagraph'
+
+/**
+ * Find URLs in an array of paragraphs
+ * @param {Array<TParagraph>} paras
+ * @returns
+ */
+export function findURLs(paras: Array<TParagraph>): Array<string> {
+  const reURL = /(http|ftp|https):\/\/([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:\/~+#-]*[\w@?^=%&\/~+#-])/gim
+  let urls = []
+  paras.forEach((para) => {
+    const matches = para.content.match(reURL)
+    if (matches) {
+      urls = [...urls, ...matches]
+    }
+  })
+  return urls
+}
+
+/**
+ * Find Links in Paragraphs Array and open in Browser
+ * @param {*} paras
+ */
+export function openLinksInNote(paras: Array<TParagraph>) {
+  const urls = findURLs(paras)
+  urls.forEach(async (url) => {
+    await NotePlan.openURL(url)
+  })
+}
+
+/**
+ * Open URLs in Editor note which are OPEN todos
+ * (Entrypoint for "/open todo links in browser" command)
+ */
+// eslint-disable-next-line require-await
+export async function openIncompleteLinksInNote() {
+  if (Editor?.note) {
+    const openParas = Editor.note.paragraphs.filter((p) => p.type === 'open')
+    openLinksInNote(openParas)
+  }
+}
+
+/**
+ * Open URLs on selected line
+ * (Entrypoint for" /open URL on this line" command)
+ */
+// eslint-disable-next-line require-await
+export async function openURLOnLine() {
+  const para = getParagraphContainingPosition(Editor.note, Editor.selection?.start || 0)
+  if (para) {
+    openLinksInNote([para])
+  }
+}

--- a/jgclark.NoteHelpers/src/index.js
+++ b/jgclark.NoteHelpers/src/index.js
@@ -25,7 +25,10 @@ export {
   openNoteNewSplit,
   renameNoteFile,
 } from './noteHelpers'
+
 export { indexFolders } from './indexFolders'
+
+export { openIncompleteLinksInNote, openURLOnLine } from './NPOpenLinks'
 
 const configKey = 'noteHelpers'
 


### PR DESCRIPTION
Hi @jgclark. I was looking for a function today to open URLs that are on open todo items in my Editor. Felt like "Note Helpers" would be a good place for it, so that's where I wrote it. See what you think.