### PR TITLE
Potential fix for ignoring last line + more logs to be sure

### DIFF
--- a/flow-typed/Noteplan.js
+++ b/flow-typed/Noteplan.js
@@ -212,7 +212,7 @@ declare interface TEditor extends CoreNoteFields {
   /**
    * Scrolls to and highlights the given range. If the paragraph is folded, it
    * will be unfolded.
-   * @param {RangeObject} range
+   * @param {Range} range
    */
   highlightByRange(range: Range): void;
   /**

--- a/helpers/NPParagraph.js
+++ b/helpers/NPParagraph.js
@@ -125,21 +125,26 @@ export async function replaceContentUnderHeading(
  * it will work as if the cursor is on the preceding heading line, and then using the same rules as above.
  * (This used to be called 'useExtendedBlockDefinition'.)
  * @author @jgclark
+ * @tests available in jest file
  *
  * @param {Array<TParagraph>} allParas - all selectedParas in the note
  * @param {number} selectedParaIndex - the index of the current Paragraph
  * @param {boolean} includeFromStartOfSection
  * @returns {Array<TParagraph>} the set of selectedParagraphs in the block
  */
-export function getParagraphBlock(note: CoreNoteFields, selectedParaIndex: number, includeFromStartOfSection: boolean = false): Array<TParagraph> {
+export function getParagraphBlock(note: CoreNoteFields,
+  selectedParaIndex: number,
+  includeFromStartOfSection: boolean = false,
+  useTightBlockDefinition: boolean = false
+): Array<TParagraph> {
   const parasInBlock: Array<TParagraph> = [] // to hold set of paragraphs in block to return
   const endOfActiveSection = findEndOfActivePartOfNote(note)
   const startOfActiveSection = findStartOfActivePartOfNote(note)
   const allParas = note.paragraphs
   let startLine = selectedParaIndex
   let selectedPara = allParas[startLine]
-  logDebug(`NPParagraph / getParagraphBlock`, `  getParaBlock: starting line ${selectedParaIndex}: '${selectedPara.content}'`)
-  logDebug(`NPParagraph / getParagraphBlock`, `  endOfActiveSection para: "${allParas[endOfActiveSection].content}"`)
+  logDebug(`NPParagraph / getParagraphBlock`, `getParaBlock: starting lineIndex ${selectedParaIndex}: '${selectedPara.content}'`)
+  logDebug(`NPParagraph / getParagraphBlock`, `- endOfActiveSection para: "${allParas[endOfActiveSection].content}"`)
 
   if (includeFromStartOfSection) {
     // First look earlier to find earlier lines up to a blank line or horizontal rule;
@@ -161,7 +166,7 @@ export function getParagraphBlock(note: CoreNoteFields, selectedParaIndex: numbe
         break
       }
     }
-    logDebug(`NPParagraph / getParagraphBlock`, `For extended block worked back and will now start at line ${startLine}`)
+    logDebug(`NPParagraph / getParagraphBlock`, `For includeFromStartOfSection worked back and will now start at line ${startLine}`)
   }
   selectedPara = allParas[startLine]
 
@@ -169,61 +174,60 @@ export function getParagraphBlock(note: CoreNoteFields, selectedParaIndex: numbe
   if (selectedPara.type === 'title') {
     // includes all heading levels
     const thisHeadingLevel = selectedPara.headingLevel
-    logDebug(`NPParagraph / getParagraphBlock`, `    Block start heading="${selectedPara.content}" (Line #${startLine})`)
-    logDebug(`NPParagraph / getParagraphBlock`, `    Found heading level ${thisHeadingLevel}`)
+    logDebug(`NPParagraph / getParagraphBlock`, `   - Block start heading "${selectedPara.content}" level ${thisHeadingLevel}. (Line #${startLine})`)
     parasInBlock.push(selectedPara) // make this the first line to move
     // Work out how far this section extends. (NB: headingRange doesn't help us here.)
-    logDebug(`NPParagraph / getParagraphBlock`, `    Scanning forward through rest of note`)
+    logDebug(`NPParagraph / getParagraphBlock`, `   - Scanning forward through rest of note`)
     for (let i = startLine + 1; i <= endOfActiveSection; i++) {
       const p = allParas[i]
       if (p.type === 'title' && p.headingLevel <= thisHeadingLevel) {
-        logDebug(`NPParagraph / getParagraphBlock`, `      ${i}: Stopping. Found new heading of same or higher level: "${p.content}"`)
+        logDebug(`NPParagraph / getParagraphBlock`, `     - ${i}: Found new heading of same or higher level: "${p.content}" -> stopping`)
         break
-      } else if (p.type === 'separator') {
-        logDebug(`NPParagraph / getParagraphBlock`, `      ${i}: Stopping. Found HR: "${p.content}"`)
+      } else if (useTightBlockDefinition && p.type === 'separator') {
+        logDebug(`NPParagraph / getParagraphBlock`, `      ${i}: Found HR: "${p.content}" -> stopping`)
         break
-      } else if (p.content === '') {
-        logDebug(`NPParagraph / getParagraphBlock`, `      ${i}: Stopping. Found blank line`)
+      } else if (useTightBlockDefinition && p.content === '') {
+        logDebug(`NPParagraph / getParagraphBlock`, `      ${i}: Found blank line -> stopping`)
         break
       }
-      logDebug(`NPParagraph / getParagraphBlock`, `    Adding to results: line[${i}]: ${p.type}: "${p.content}"`)
+      logDebug(`NPParagraph / getParagraphBlock`, `   - Adding to results: line[${i}]: ${p.type}: "${p.content}"`)
       parasInBlock.push(p)
     }
     logDebug(`NPParagraph / getParagraphBlock`, `  Found ${parasInBlock.length} heading section lines`)
   } else {
     // This isn't a heading
     const startingIndentLevel = selectedPara.indents
-    logDebug(`NPParagraph / getParagraphBlock`, `  Found single line with indent level ${startingIndentLevel}`)
+    logDebug(`NPParagraph / getParagraphBlock`, `- Found single line with indent level ${startingIndentLevel}`)
     parasInBlock.push(selectedPara)
 
     // See if there are following indented lines to move as well
     for (let i = startLine + 1; i <= endOfActiveSection; i++) {
       const p = allParas[i]
       logDebug(`NPParagraph / getParagraphBlock`, `  ${i} / indent ${p.indents} / ${p.content}`)
-      // stop if horizontal line
-      if (p.type === 'separator') {
-        logDebug(`NPParagraph / getParagraphBlock`, `      ${i}: Found HR`)
+      if (useTightBlockDefinition && p.type === 'separator') {
+        // stop if horizontal line
+        logDebug(`NPParagraph / getParagraphBlock`, `      ${i}: Found HR -> stopping`)
+        break
+      } else if (useTightBlockDefinition && p.content === '') {
+        logDebug(`NPParagraph / getParagraphBlock`, `      ${i}: Found blank line -> stopping`)
         break
       } else if (p.type === 'title') {
-        logDebug(`NPParagraph / getParagraphBlock`, `      ${i}: Found heading`)
+        logDebug(`NPParagraph / getParagraphBlock`, `      ${i}: Found heading -> stopping`)
         break
-      } else if (p.content === '') {
-        logDebug(`NPParagraph / getParagraphBlock`, `      ${i}: Found blank line`)
-        break
-      } else if (p.indents <= startingIndentLevel && !includeFromStartOfSection) {
+      } else if (p.indents < startingIndentLevel && !includeFromStartOfSection) {
         // if we aren't using the Extended Block Definition, then
-        // stop as this selectedPara is same or less indented than the starting line
-        logDebug(`NPParagraph / getParagraphBlock`, `      ${i}: Stopping as found same or lower indent`)
+        // stop as this selectedPara is less indented than the starting line
+        logDebug(`NPParagraph / getParagraphBlock`, `      ${i}: Found same or lower indent -> stopping`)
         break
       }
       parasInBlock.push(p) // add onto end of array
     }
   }
 
-  logDebug(`NPParagraph / getParagraphBlock`, `  Found ${parasInBlock.length} paras in block starting with: "${allParas[selectedParaIndex].content}"`)
-  // for (const pib of parasInBlock) {
-  //   log(`NPParagraph / getParagraphBlock`, `    ${ pib.content }`)
-  // }
+  logDebug(`NPParagraph / getParagraphBlock`, `  - Found ${parasInBlock.length} paras in block starting with: "${allParas[selectedParaIndex].content}"`)
+  for (const pib of parasInBlock) {
+    log(`NPParagraph / getParagraphBlock`, `    ${pib.content}`)
+  }
   return parasInBlock
 }
 
@@ -245,8 +249,7 @@ export function getBlockUnderHeading(note: TNote, heading: TParagraph | string, 
     headingPara = heading
   }
   let paras: Array<TParagraph> = []
-  if (headingPara?.lineIndex !== null) {
-    // $FlowFixMe(incompataible-use)
+  if (headingPara?.lineIndex != null) {
     paras = getParagraphBlock(note, headingPara.lineIndex)
   }
   if (paras.length && !returnHeading) {

--- a/helpers/NPParagraph.js
+++ b/helpers/NPParagraph.js
@@ -139,6 +139,7 @@ export function getParagraphBlock(note: CoreNoteFields, selectedParaIndex: numbe
   let startLine = selectedParaIndex
   let selectedPara = allParas[startLine]
   logDebug(`NPParagraph / getParagraphBlock`, `  getParaBlock: starting line ${selectedParaIndex}: '${selectedPara.content}'`)
+  logDebug(`NPParagraph / getParagraphBlock`, `  endOfActiveSection para: "${allParas[endOfActiveSection].content}"`)
 
   if (includeFromStartOfSection) {
     // First look earlier to find earlier lines up to a blank line or horizontal rule;
@@ -168,32 +169,35 @@ export function getParagraphBlock(note: CoreNoteFields, selectedParaIndex: numbe
   if (selectedPara.type === 'title') {
     // includes all heading levels
     const thisHeadingLevel = selectedPara.headingLevel
+    logDebug(`NPParagraph / getParagraphBlock`, `    Block start heading="${selectedPara.content}" (Line #${startLine})`)
     logDebug(`NPParagraph / getParagraphBlock`, `    Found heading level ${thisHeadingLevel}`)
     parasInBlock.push(selectedPara) // make this the first line to move
     // Work out how far this section extends. (NB: headingRange doesn't help us here.)
-    for (let i = startLine + 1; i < endOfActiveSection; i++) {
+    logDebug(`NPParagraph / getParagraphBlock`, `    Scanning forward through rest of note`)
+    for (let i = startLine + 1; i <= endOfActiveSection; i++) {
       const p = allParas[i]
       if (p.type === 'title' && p.headingLevel <= thisHeadingLevel) {
-        logDebug(`NPParagraph / getParagraphBlock`, `      ${i}: ${i}: Found new heading of same or higher level`)
+        logDebug(`NPParagraph / getParagraphBlock`, `      ${i}: Stopping. Found new heading of same or higher level: "${p.content}"`)
         break
       } else if (p.type === 'separator') {
-        logDebug(`NPParagraph / getParagraphBlock`, `      ${i}: Found HR`)
+        logDebug(`NPParagraph / getParagraphBlock`, `      ${i}: Stopping. Found HR: "${p.content}"`)
         break
       } else if (p.content === '') {
-        logDebug(`NPParagraph / getParagraphBlock`, `      ${i}: Found blank line`)
+        logDebug(`NPParagraph / getParagraphBlock`, `      ${i}: Stopping. Found blank line`)
         break
       }
+      logDebug(`NPParagraph / getParagraphBlock`, `    Adding to results: line[${i}]: ${p.type}: "${p.content}"`)
       parasInBlock.push(p)
     }
     logDebug(`NPParagraph / getParagraphBlock`, `  Found ${parasInBlock.length} heading section lines`)
   } else {
     // This isn't a heading
     const startingIndentLevel = selectedPara.indents
-    log(`NPParagraph / getParagraphBlock`, `  Found single line with indent level ${startingIndentLevel}`)
+    logDebug(`NPParagraph / getParagraphBlock`, `  Found single line with indent level ${startingIndentLevel}`)
     parasInBlock.push(selectedPara)
 
     // See if there are following indented lines to move as well
-    for (let i = startLine + 1; i < endOfActiveSection; i++) {
+    for (let i = startLine + 1; i <= endOfActiveSection; i++) {
       const p = allParas[i]
       logDebug(`NPParagraph / getParagraphBlock`, `  ${i} / indent ${p.indents} / ${p.content}`)
       // stop if horizontal line

--- a/helpers/NPParagraph.js
+++ b/helpers/NPParagraph.js
@@ -1,5 +1,6 @@
 // @flow
 
+import { trimString } from './dataManipulation'
 import { hyphenatedDate } from './dateTime'
 import { toLocaleDateTimeString } from './NPdateTime'
 import { JSP, log, logDebug, logError, logWarn, timer } from './dev'
@@ -138,30 +139,29 @@ export function getParagraphBlock(note: CoreNoteFields,
   useTightBlockDefinition: boolean = false
 ): Array<TParagraph> {
   const parasInBlock: Array<TParagraph> = [] // to hold set of paragraphs in block to return
-  const endOfActiveSection = findEndOfActivePartOfNote(note)
-  const startOfActiveSection = findStartOfActivePartOfNote(note)
+  const startActiveLineIndex = findStartOfActivePartOfNote(note)
+  const endActiveLineIndex = findEndOfActivePartOfNote(note)
   const allParas = note.paragraphs
   let startLine = selectedParaIndex
   let selectedPara = allParas[startLine]
-  logDebug(`NPParagraph / getParagraphBlock`, `getParaBlock: starting lineIndex ${selectedParaIndex}: '${selectedPara.content}'`)
-  logDebug(`NPParagraph / getParagraphBlock`, `- endOfActiveSection para: "${allParas[endOfActiveSection].content}"`)
+  logDebug(`NPParagraph / getParagraphBlock`, `getParaBlock: starting with start/end active = ${startActiveLineIndex}/${endActiveLineIndex} at lineIndex ${selectedParaIndex} ('${trimString(selectedPara.content, 50)}')`)
 
   if (includeFromStartOfSection) {
     // First look earlier to find earlier lines up to a blank line or horizontal rule;
     // include line unless we hit a new heading, an empty line, or a less-indented line.
-    for (let i = selectedParaIndex - 1; i >= startOfActiveSection - 1; i--) {
+    for (let i = selectedParaIndex - 1; i >= startActiveLineIndex; i--) {
       const p = allParas[i]
-      logDebug(`NPParagraph / getParagraphBlock`, `  ${i} / ${p.type} / ${p.content}`)
+      // logDebug(`NPParagraph / getParagraphBlock`, `  ${i} / ${p.type} / ${trimString(p.content, 50)}`)
       if (p.type === 'separator') {
-        logDebug(`NPParagraph / getParagraphBlock`, `      ${i}: Found separator line`)
+        logDebug(`NPParagraph / getParagraphBlock`, `   - ${i}: Found separator line`)
         startLine = i + 1
         break
       } else if (p.content === '') {
-        logDebug(`NPParagraph / getParagraphBlock`, `      ${i}: Found blank line`)
+        logDebug(`NPParagraph / getParagraphBlock`, `  - ${i}: Found blank line`)
         startLine = i + 1
         break
       } else if (p.type === 'title') {
-        logDebug(`NPParagraph / getParagraphBlock`, `      ${i}: Found heading`)
+        logDebug(`NPParagraph / getParagraphBlock`, `  - ${i}: Found heading`)
         startLine = i
         break
       }
@@ -174,50 +174,50 @@ export function getParagraphBlock(note: CoreNoteFields,
   if (selectedPara.type === 'title') {
     // includes all heading levels
     const thisHeadingLevel = selectedPara.headingLevel
-    logDebug(`NPParagraph / getParagraphBlock`, `   - Block start heading "${selectedPara.content}" level ${thisHeadingLevel}. (Line #${startLine})`)
+    logDebug(`NPParagraph / getParagraphBlock`, `- Block starts line ${startLine} at heading '${selectedPara.content}' level ${thisHeadingLevel}`)
     parasInBlock.push(selectedPara) // make this the first line to move
     // Work out how far this section extends. (NB: headingRange doesn't help us here.)
-    logDebug(`NPParagraph / getParagraphBlock`, `   - Scanning forward through rest of note`)
-    for (let i = startLine + 1; i <= endOfActiveSection; i++) {
+    logDebug(`NPParagraph / getParagraphBlock`, `- Scanning forward through rest of note ...`)
+    for (let i = startLine + 1; i <= endActiveLineIndex; i++) {
       const p = allParas[i]
       if (p.type === 'title' && p.headingLevel <= thisHeadingLevel) {
-        logDebug(`NPParagraph / getParagraphBlock`, `     - ${i}: Found new heading of same or higher level: "${p.content}" -> stopping`)
+        logDebug(`NPParagraph / getParagraphBlock`, `  - ${i}: Found new heading of same or higher level: "${p.content}" -> stopping`)
         break
       } else if (useTightBlockDefinition && p.type === 'separator') {
-        logDebug(`NPParagraph / getParagraphBlock`, `      ${i}: Found HR: "${p.content}" -> stopping`)
+        logDebug(`NPParagraph / getParagraphBlock`, `  - ${i}: Found HR: "${p.content}" -> stopping`)
         break
       } else if (useTightBlockDefinition && p.content === '') {
-        logDebug(`NPParagraph / getParagraphBlock`, `      ${i}: Found blank line -> stopping`)
+        logDebug(`NPParagraph / getParagraphBlock`, `  - ${i}: Found blank line -> stopping`)
         break
       }
-      logDebug(`NPParagraph / getParagraphBlock`, `   - Adding to results: line[${i}]: ${p.type}: "${p.content}"`)
+      logDebug(`NPParagraph / getParagraphBlock`, `  - Adding to results: line[${i}]: ${p.type}: "${trimString(p.content, 50)}"`)
       parasInBlock.push(p)
     }
-    logDebug(`NPParagraph / getParagraphBlock`, `  Found ${parasInBlock.length} heading section lines`)
+    logDebug(`NPParagraph / getParagraphBlock`, `- Found ${parasInBlock.length} heading section lines`)
   } else {
     // This isn't a heading
     const startingIndentLevel = selectedPara.indents
-    logDebug(`NPParagraph / getParagraphBlock`, `- Found single line with indent level ${startingIndentLevel}`)
+    logDebug(`NPParagraph / getParagraphBlock`, `Found single line with indent level ${startingIndentLevel}. Now scanning forward through rest of note ...`)
     parasInBlock.push(selectedPara)
 
     // See if there are following indented lines to move as well
-    for (let i = startLine + 1; i <= endOfActiveSection; i++) {
+    for (let i = startLine + 1; i <= endActiveLineIndex; i++) {
       const p = allParas[i]
-      logDebug(`NPParagraph / getParagraphBlock`, `  ${i} / indent ${p.indents} / ${p.content}`)
+      // logDebug(`NPParagraph / getParagraphBlock`, `  ${i} / indent ${p.indents} / ${trimString(p.content, 50)}`)
       if (useTightBlockDefinition && p.type === 'separator') {
         // stop if horizontal line
-        logDebug(`NPParagraph / getParagraphBlock`, `      ${i}: Found HR -> stopping`)
+        logDebug(`NPParagraph / getParagraphBlock`, `  - ${i}: Found HR -> stopping`)
         break
       } else if (useTightBlockDefinition && p.content === '') {
-        logDebug(`NPParagraph / getParagraphBlock`, `      ${i}: Found blank line -> stopping`)
+        logDebug(`NPParagraph / getParagraphBlock`, `  - ${i}: Found blank line -> stopping`)
         break
       } else if (p.type === 'title') {
-        logDebug(`NPParagraph / getParagraphBlock`, `      ${i}: Found heading -> stopping`)
+        logDebug(`NPParagraph / getParagraphBlock`, `  - ${i}: Found heading -> stopping`)
         break
       } else if (p.indents < startingIndentLevel && !includeFromStartOfSection) {
         // if we aren't using the Extended Block Definition, then
         // stop as this selectedPara is less indented than the starting line
-        logDebug(`NPParagraph / getParagraphBlock`, `      ${i}: Found same or lower indent -> stopping`)
+        logDebug(`NPParagraph / getParagraphBlock`, `  - ${i}: Found same or lower indent -> stopping`)
         break
       }
       parasInBlock.push(p) // add onto end of array
@@ -225,9 +225,9 @@ export function getParagraphBlock(note: CoreNoteFields,
   }
 
   logDebug(`NPParagraph / getParagraphBlock`, `  - Found ${parasInBlock.length} paras in block starting with: "${allParas[selectedParaIndex].content}"`)
-  for (const pib of parasInBlock) {
-    log(`NPParagraph / getParagraphBlock`, `    ${pib.content}`)
-  }
+  // for (const pib of parasInBlock) {
+  //   log(`NPParagraph / getParagraphBlock`, `  ${pib.content}`)
+  // }
   return parasInBlock
 }
 

--- a/helpers/__tests__/NPParagraphs.tests.js
+++ b/helpers/__tests__/NPParagraphs.tests.js
@@ -16,8 +16,11 @@ beforeEach(() => {
   const paragraphs = [
     new Paragraph({ type: 'title', content: 'theTitle', headingLevel: 1, indents: 0, lineIndex: 0 }),
     new Paragraph({ type: 'text', content: 'line 2', headingLevel: 1, indents: 0, lineIndex: 1 }),
-    new Paragraph({ type: 'empty', content: '', headingLevel: 1, indents: 0, lineIndex: 2 }),
-    new Paragraph({ type: 'text', content: 'line 3', headingLevel: 1, indents: 0, lineIndex: 3 }),
+    new Paragraph({ type: 'text', content: 'line 3 (child of 2)', headingLevel: 1, indents: 1, lineIndex: 2 }),
+    new Paragraph({ type: 'text', content: 'line 4', headingLevel: 1, indents: 0, lineIndex: 3 }),
+    new Paragraph({ type: 'empty', content: '', headingLevel: 1, indents: 0, lineIndex: 4 }),
+    new Paragraph({ type: 'separator', content: '---', lineIndex: 5 }),
+    new Paragraph({ type: 'title', content: 'Done', headingLevel: 2, indents: 0, lineIndex: 6 }),
   ]
   Editor.note = new Note({ paragraphs })
 })
@@ -48,17 +51,87 @@ describe('findHeading()' /* function */, () => {
 /*
  * getBlockUnderHeading()
  */
-describe('getBlockUnderHeading()' /* function */, () => {
-  test('should return block when passed a string', () => {
-    const result = p.getBlockUnderHeading(Editor.note, 'theTitle')
-    expect(result.length).toEqual(2)
-    expect(result[0].content).toEqual(`theTitle`)
-    expect(result[1].content).toEqual(`line 2`)
+describe('getParagraphBlock()' /* function */, () => {
+  test('should return block lineIndex 0-4 from 0/false/false', () => {
+    const result = p.getParagraphBlock(Editor.note, 0, false, false)
+    expect(result).toEqual(Editor.note.paragraphs.slice(0, 5))
   })
-  test('should return block when passed a paragraph', () => {
-    const result = p.getBlockUnderHeading(Editor.note, Editor.note.paragraphs[0])
-    expect(result.length).toEqual(2)
-    expect(result[0].content).toEqual(`theTitle`)
-    expect(result[1].content).toEqual(`line 2`)
+  test('should return block lineIndex 0-3 from 0/false/true', () => {
+    const result = p.getParagraphBlock(Editor.note, 0, false, true)
+    expect(result).toEqual(Editor.note.paragraphs.slice(0, 4))
+  })
+  test('should return block lineIndex 0-4 from 0/true/false', () => {
+    const result = p.getParagraphBlock(Editor.note, 0, true, false)
+    expect(result).toEqual(Editor.note.paragraphs.slice(0, 5))
+  })
+  test('should return block lineIndex 0-3 from 0/true/true', () => {
+    const result = p.getParagraphBlock(Editor.note, 0, true, true)
+    expect(result).toEqual(Editor.note.paragraphs.slice(0, 4))
+  })
+
+  test('should return block lineIndex 1-4 from 1/false/false', () => {
+    const result = p.getParagraphBlock(Editor.note, 1, false, false)
+    expect(result).toEqual(Editor.note.paragraphs.slice(1, 5))
+  })
+  test('should return block lineIndex 1-3 from 1/false/true', () => {
+    const result = p.getParagraphBlock(Editor.note, 1, false, true)
+    expect(result).toEqual(Editor.note.paragraphs.slice(1, 4))
+  })
+  test('should return block lineIndex 0-4 from 1/true/false', () => {
+    const result = p.getParagraphBlock(Editor.note, 1, true, false)
+    expect(result).toEqual(Editor.note.paragraphs.slice(0, 5))
+  })
+  test('should return block lineIndex 0-3 from 1/true/true', () => {
+    const result = p.getParagraphBlock(Editor.note, 1, true, true)
+    expect(result).toEqual(Editor.note.paragraphs.slice(0, 4))
+  })
+
+  test('should return block lineIndex 2 from 2/false/false', () => {
+    const result = p.getParagraphBlock(Editor.note, 2, false, false)
+    expect(result).toEqual(Editor.note.paragraphs.slice(2, 3))
+  })
+  test('should return block lineIndex 2 from 2/false/true', () => {
+    const result = p.getParagraphBlock(Editor.note, 2, false, true)
+    expect(result).toEqual(Editor.note.paragraphs.slice(2, 3))
+  })
+  test('should return block lineIndex 0-4 from 2/true/false', () => {
+    const result = p.getParagraphBlock(Editor.note, 2, true, false)
+    expect(result).toEqual(Editor.note.paragraphs.slice(0, 5))
+  })
+  test('should return block lineIndex 0-3 from 2/true/true', () => {
+    const result = p.getParagraphBlock(Editor.note, 2, true, true)
+    expect(result).toEqual(Editor.note.paragraphs.slice(0, 4))
+  })
+})
+
+/*
+ * getBlockUnderHeading()
+ */
+describe('getBlockUnderHeading()' /* function */, () => {
+  test('should return block (with heading) when passed a heading string', () => {
+    const result = p.getBlockUnderHeading(Editor.note, 'theTitle', true)
+    expect(result).toEqual(Editor.note.paragraphs.slice(0, 5))
+    // expect(result.length).toEqual(2)
+    // expect(result[0].content).toEqual(`theTitle`)
+    // expect(result[1].content).toEqual(`line 2`)
+  })
+  test('should return block (without heading) when passed a heading string', () => {
+    const result = p.getBlockUnderHeading(Editor.note, 'theTitle', false)
+    expect(result).toEqual(Editor.note.paragraphs.slice(1, 5))
+    // expect(result.length).toEqual(1)
+    // expect(result[0].content).toEqual(`line 2`)
+  })
+  test('should return block (with heading) when passed a heading paragraph', () => {
+    const result = p.getBlockUnderHeading(Editor.note, Editor.note.paragraphs[0], true)
+    expect(result).toEqual(Editor.note.paragraphs.slice(0, 5))
+    // expect(result.length).toEqual(2)
+    // expect(result[0].content).toEqual(`theTitle`)
+    // expect(result[1].content).toEqual(`line 2`)
+  })
+  test('should return block (without heading) when passed a heading paragraph', () => {
+    const result = p.getBlockUnderHeading(Editor.note, Editor.note.paragraphs[0], false)
+    expect(result).toEqual(Editor.note.paragraphs.slice(1, 5))
+    // expect(result.length).toEqual(1)
+    // expect(result[0].content).toEqual(`line 2`)
   })
 })

--- a/helpers/__tests__/paragraphs.test.js
+++ b/helpers/__tests__/paragraphs.test.js
@@ -194,9 +194,9 @@ describe('paragraph.js', () => {
         { type: 'title', lineIndex: 12, content: 'Done (more)', headingLevel: 2 },
       ],
     }
-    test('should find at line 6 (note A)', () => {
+    test('should find at line 5 (note A)', () => {
       const result = p.findEndOfActivePartOfNote(noteA)
-      expect(result).toEqual(6)
+      expect(result).toEqual(5)
     })
     const noteB = {
       paragraphs: [
@@ -215,9 +215,9 @@ describe('paragraph.js', () => {
         { type: 'title', lineIndex: 12, content: 'Done (more)', headingLevel: 2 },
       ],
     }
-    test('should find at line 5 (note B)', () => {
+    test('should find at line 4 (note B)', () => {
       const result = p.findEndOfActivePartOfNote(noteB)
-      expect(result).toEqual(5)
+      expect(result).toEqual(4)
     })
     const noteC = {
       paragraphs: [
@@ -235,27 +235,28 @@ describe('paragraph.js', () => {
         { type: 'cancelled', lineIndex: 11, content: 'task 4 not done' },
       ],
     }
-    test('should find at line 10 (note C)', () => {
+    test('should find at line 9 (note C)', () => {
       const result = p.findEndOfActivePartOfNote(noteC)
-      expect(result).toEqual(10)
+      expect(result).toEqual(9)
     })
     const noteD = {
       paragraphs: [
         { type: 'title', lineIndex: 0, content: 'NoteB Title', headingLevel: 1 },
-        { type: 'empty', lineIndex: 1 },
+        { type: 'empty', lineIndex: 1, content: '' },
         { type: 'title', lineIndex: 2, content: 'Section 1', headingLevel: 2 },
         { type: 'open', lineIndex: 3, content: 'task 1' },
         { type: 'text', lineIndex: 4, content: 'some ordinary text' },
-        { type: 'empty', lineIndex: 5 },
+        { type: 'empty', lineIndex: 5, content: '' },
         { type: 'title', lineIndex: 6, content: 'Section 2', headingLevel: 3 },
         { type: 'quote', lineIndex: 7, content: 'quotation' },
         { type: 'done', lineIndex: 8, content: 'task 3 done' },
-        { type: 'empty', lineIndex: 9 },
+        { type: 'empty', lineIndex: 9, content: '' },
         { type: 'title', lineIndex: 10, content: 'Section 3...', headingLevel: 2 },
         { type: 'cancelled', lineIndex: 11, content: 'task 4 not done' },
+        { type: 'empty', lineIndex: 12, content: '' },
       ],
     }
-    test('should not find either (note D), so do last lineIndex', () => {
+    test('should not find either (note D), so do last non-empty lineIndex (11)', () => {
       const result = p.findEndOfActivePartOfNote(noteD)
       expect(result).toEqual(11)
     })

--- a/helpers/dataManipulation.js
+++ b/helpers/dataManipulation.js
@@ -16,6 +16,19 @@ export function trimAnyQuotes(inStr: string): string {
 }
 
 /**
+ * Trims a string to be be no more than maxLen long; if trimmed add '...'
+ * @author @jgclark
+ * 
+ * @param {string} inStr the string to trim
+ * @returns {string}
+ */
+export function trimString(inStr: string, maxLen: number): string {
+  return inStr.length > maxLen
+    ? inStr.slice(0, maxLen) + ' ...'
+    : inStr
+}
+
+/**
  * Cast boolean from the config mixed. Based on @m1well's config system.
  *
  * @param val the config mixed

--- a/helpers/paragraph.js
+++ b/helpers/paragraph.js
@@ -226,9 +226,9 @@ export function smartPrependPara(note: TNote, paraText: string, paragraphType: P
 }
 
 /**
- * Works out where the first ## Done or ## Cancelled section starts, if present.
+ * Works out where the first ## Done or ## Cancelled section starts, if present, and returns the paragraph before that.
  * Works with folded Done or Cancelled sections.
- * If the previous line was a separator, use that line instead
+ * If the result is a separator, use the line before that instead
  * If neither Done or Cancelled present, return the last non-empty lineIndex.
  * @author @jgclark
  * @tests in jest file
@@ -266,7 +266,10 @@ export function findEndOfActivePartOfNote(note: CoreNoteFields): number {
       cancelledHeaderLine -= 1
     }
 
-    const endOfActive = doneHeaderLine > 0 ? doneHeaderLine : cancelledHeaderLine > 0 ? cancelledHeaderLine : lineCount > 0 ? lineCount - 1 : 0
+    const endOfActive = doneHeaderLine > 1 ? doneHeaderLine - 1
+      : cancelledHeaderLine > 1 ? cancelledHeaderLine - 1
+        : lineCount > 1 ? lineCount - 1
+          : 0
     logDebug('paragraph/findEndOfActivePartOfNote', `doneHeaderLine = ${doneHeaderLine}, cancelledHeaderLine = ${cancelledHeaderLine} endOfActive = ${endOfActive}`)
     return endOfActive
   }

--- a/jgclark.Filer/CHANGELOG.md
+++ b/jgclark.Filer/CHANGELOG.md
@@ -4,6 +4,11 @@ Please see the [Readme for this plugin](https://github.com/NotePlan/plugins/tree
 <!-- ### Added
 - [when environment() API call is available] ??? will use system locale in dates, where possible
 -->
+## [0.9.0-beta1] - 2022-08-04
+### Changed
+- Split a setting into two: 'Include lines from start of Section in the Block?' and 'Use a tighter definition of when a Block finishes?'  This gives more control over the number of lines that are automatically selected to move. _You can still manually select a specific range of lines to move._
+- ??? where the command is working out which lines to include in the block, it will now show them highlighted while it's asking which note to move them to. This provides a useful way of checking it's doing what you expect.
+
 ## [0.8.1] - 2022-06-27
 ### Added
 - new **/new note from clipboard** command (alias **nnc**) added back in from 0.7.0 beta

--- a/jgclark.Filer/CHANGELOG.md
+++ b/jgclark.Filer/CHANGELOG.md
@@ -2,16 +2,16 @@
 Please see the [Readme for this plugin](https://github.com/NotePlan/plugins/tree/main/jgclark.Filer) for more details, including the available settings.
 
 <!-- ### Added
-- [when environment() API call is available] ??? will use system locale in dates, where possible
+- ??? where the command is working out which lines to include in the block, it will now show them highlighted while it's asking which note to move them to. This provides a useful way of checking it's doing what you expect.
 -->
-## [0.9.0-beta1] - 2022-08-04
+## [0.9.0] - 2022-08-05
 ### Changed
 - Split a setting into two: 'Include lines from start of Section in the Block?' and 'Use a tighter definition of when a Block finishes?'  This gives more control over the number of lines that are automatically selected to move. _You can still manually select a specific range of lines to move._
-- ??? where the command is working out which lines to include in the block, it will now show them highlighted while it's asking which note to move them to. This provides a useful way of checking it's doing what you expect.
 
 ## [0.8.1] - 2022-06-27
 ### Added
 - new **/new note from clipboard** command (alias **nnc**) added back in from 0.7.0 beta
+- now formats date links using your system's default date formatter
 
 ## [0.8.0] - 2022-06-25
 ### Added

--- a/jgclark.Filer/plugin.json
+++ b/jgclark.Filer/plugin.json
@@ -7,8 +7,8 @@
   "plugin.icon": "",
   "plugin.author": "jgclark",
   "plugin.url": "https://github.com/NotePlan/plugins/tree/main/jgclark.Filer",
-  "plugin.version": "0.8.1",
-  "plugin.lastUpdateInfo": "Add '/new note from clipboard' command",
+  "plugin.version": "0.9.0-beta1",
+  "plugin.lastUpdateInfo": "Split a setting into two: 'Include lines from start of Section in the Block?' and 'Use a tighter definition of when a Block finishes?'",
   "plugin.dependencies": [],
   "plugin.script": "script.js",
   "plugin.isRemote": "false",
@@ -20,7 +20,7 @@
         "fp",
         "file"
       ],
-      "description": "move (file) paragraphs to different notes",
+      "description": "move (file) a block of paragraphs to different notes",
       "jsFunction": "moveParas"
     },
     {
@@ -40,7 +40,7 @@
         "day",
         "daily"
       ],
-      "description": "quick move paragraphs to Today's note",
+      "description": "quick move a block of paragraphs to Today's note",
       "jsFunction": "moveParasToToday"
     },
     {
@@ -50,7 +50,7 @@
         "day",
         "daily"
       ],
-      "description": "quick move paragraphs to Tomorrow's daily note",
+      "description": "quick move a block of paragraphs to Tomorrow's daily note",
       "jsFunction": "moveParasToTomorrow"
     },
     {
@@ -59,7 +59,7 @@
         "qmtw",
         "week"
       ],
-      "description": "quick move paragraphs to the current Weekly note",
+      "description": "quick move a block of paragraphs to the current Weekly note",
       "jsFunction": "moveParasToThisWeekly"
     },
     {
@@ -68,7 +68,7 @@
         "qmnw",
         "week"
       ],
-      "description": "quick move paragraphs to Next Week's note",
+      "description": "quick move a block of paragraphs to Next Week's note",
       "jsFunction": "moveParasToNextWeekly"
     },
     {
@@ -106,6 +106,34 @@
       "title": "Filer plugin settings"
     },
     {
+      "key": "includeFromStartOfSection",
+      "title": "Include lines from start of Section in the Block?",
+      "description": "Controls whether all the lines in the current heading's section are included in the block to move (true) or whether only the following ones that are more deeply indented are included (false; this is the default).",
+      "type": "bool",
+      "default": false,
+      "required": true
+    },
+    {
+      "key": "useTightBlockDefinition",
+      "title": "Use a tighter definition of when a Block finishes?",
+      "description": "By default a Block includes blank lines and separators. If you wish those to instead mark the end of a Block, then set this to true.",
+      "type": "bool",
+      "default": false,
+      "required": true
+    },
+    {
+      "key": "whereToAddInSection",
+      "title": "Where to add in section",
+      "description": "Controls whether moved lines get inserted at the \"start\" or \"end\" of the chosen section.",
+      "type": "string",
+      "choices": [
+        "start",
+        "end"
+      ],
+      "default": "start",
+      "required": true
+    },
+    {
       "key": "addDateBacklink",
       "title": "Add date reference?",
       "description": "If true, adds date reference on the moved paragraph(s) when moved from a daily note.",
@@ -124,26 +152,6 @@
         "link"
       ],
       "default": "link",
-      "required": true
-    },
-    {
-      "key": "useExtendedBlockDefinition",
-      "title": "Use extended block definition?",
-      "description": "Controls whether all the lines in the current heading's section are included in the block to move (true) or whether only the following ones that are more deeply indented are included (false; this is the default). In both cases a block is closed by a blank line or a separator (horizontal line).",
-      "type": "bool",
-      "default": false,
-      "required": true
-    },
-    {
-      "key": "whereToAddInSection",
-      "title": "Where to add in section",
-      "description": "Controls whether moved lines get inserted at the \"start\" or \"end\" of the chosen section.",
-      "type": "string",
-      "choices": [
-        "start",
-        "end"
-      ],
-      "default": "start",
       "required": true
     }
   ]

--- a/jgclark.Filer/plugin.json
+++ b/jgclark.Filer/plugin.json
@@ -7,7 +7,7 @@
   "plugin.icon": "",
   "plugin.author": "jgclark",
   "plugin.url": "https://github.com/NotePlan/plugins/tree/main/jgclark.Filer",
-  "plugin.version": "0.9.0-beta1",
+  "plugin.version": "0.9.0",
   "plugin.lastUpdateInfo": "Split a setting into two: 'Include lines from start of Section in the Block?' and 'Use a tighter definition of when a Block finishes?'",
   "plugin.dependencies": [],
   "plugin.script": "script.js",

--- a/jgclark.Filer/src/fileItems.js
+++ b/jgclark.Filer/src/fileItems.js
@@ -2,7 +2,7 @@
 // ----------------------------------------------------------------------------
 // Plugin to help move selected Paragraphs to other notes
 // Jonathan Clark
-// last updated 24.7.2022 for v0.8.0+
+// last updated 4.8.2022 for v0.9.0
 // ----------------------------------------------------------------------------
 
 import pluginJson from "../plugin.json"
@@ -10,8 +10,11 @@ import {
   hyphenatedDate,
   toLocaleDateTimeString
 } from '@helpers/dateTime'
-import { logDebug, logError, logWarn } from '@helpers/dev'
-// import { displayTitle } from '@helpers/general'
+import { clo, logDebug, logError, logWarn } from '@helpers/dev'
+import {
+  displayTitle,
+  rangeToString
+} from '@helpers/general'
 import { allNotesSortedByChanged } from '@helpers/note'
 import {
   calcSmartPrependPoint,
@@ -23,6 +26,7 @@ import {
   selectedLinesIndex,
   // getSelectedParaIndex,
 } from '@helpers/NPParagraph'
+import first from "eslint-plugin-import/lib/rules/first";
 
 //-----------------------------------------------------------------------------
 // Get settings
@@ -32,7 +36,8 @@ const pluginID = 'jgclark.Filer'
 type FilerConfig = {
   addDateBacklink: boolean,
   dateRefStyle: string,
-  useExtendedBlockDefinition: boolean,
+  includeFromStartOfSection: boolean,
+  useTightBlockDefinition: boolean,
   whereToAddInSection: string, // 'start' (default) or 'end'
 }
 
@@ -42,11 +47,11 @@ export async function getFilerSettings(): Promise<any> {
     const v2Config: FilerConfig = await DataStore.loadJSON("../jgclark.Filer/settings.json")
 
     if (v2Config == null || Object.keys(v2Config).length === 0) {
-      logDebug(pluginJson, `getFilerSettings() cannot find '${pluginID}' plugin settings. Stopping.`)
+      logWarn(pluginJson, `getFilerSettings() cannot find '${pluginID}' plugin settings. Stopping.`)
       await showMessage(`Cannot find settings for the '${pluginID}' plugin. Please make sure you have installed it from the Plugin Preferences pane.`)
       return
     } else {
-      // clo(v2Config, `${pluginID} settings from V2:`)
+      clo(v2Config, `${pluginID} settings from V2:`)
       return v2Config
     }
   } catch (err) {
@@ -59,80 +64,105 @@ export async function getFilerSettings(): Promise<any> {
 
 /**
  * Move text to a different note.
- * NB: Can't selecet dates with no existing Calendar note.
- * Note: Waiting for better date picker from Eduard before working further on this.
+ * NB: Can't select dates without an existing Calendar note.
+ *   Note: Waiting for better date picker from Eduard before working further on this.
  *
  * This is how we identify what we're moving (in priority order):
  * - current selection
  * - current heading + its following section
  * - current line
  * - current line (plus any paragraphs directly following). NB: the Setting
- *   'useExtendedBlockDefinition' decides whether these directly following paragaphs
+ *   'includeFromStartOfSection' decides whether these directly following paragaphs
  *   have to be indented (false) or can take all following lines at same level until next
  *   empty line as well.
  * @author @jgclark
  */
 export async function moveParas(): Promise<void> {
-  const { content, paragraphs, selectedParagraphs, note } = Editor
-  if (content == null || selectedParagraphs == null || note == null) {
-    // No note open, or no selectedParagraph selection (perhaps empty note), so don't do anything.
-    logWarn(pluginJson, 'moveParas: No note open, so stopping.')
-    return
+  try {
+    logDebug(pluginJson, `moveParas: starting ...`)
+    const { content, paragraphs, selectedParagraphs, note } = Editor
+    if (content == null || selectedParagraphs == null || note == null) {
+      // No note open, or no selectedParagraph selection (perhaps empty note), so don't do anything.
+      logWarn(pluginJson, 'moveParas: No note open, so stopping.')
+      return
+    }
+
+    // Get config settings
+    const config = await getFilerSettings()
+
+    // Get current selection, and its range
+    const selection = Editor.selection
+    if (selection == null) {
+      // Really a belt-and-braces check that the editor is active
+      logWarn(pluginJson, 'moveParas: No selection found, so stopping.')
+      return
+    }
+    // Get paragraph indexes for the start and end of the selection (can be the same)
+    const [firstSelLineIndex, lastSelLineIndex] = selectedLinesIndex(selection, paragraphs)
+    // Get paragraphs for the selection or block
+    let parasInBlock: Array<TParagraph>
+    if (lastSelLineIndex !== firstSelLineIndex) {
+      logDebug(pluginJson, `- user has selected lineIndexes ${firstSelLineIndex}-${lastSelLineIndex}`)
+      parasInBlock = selectedParagraphs.slice() // copy to avoid $ReadOnlyArray problem
+    } else {
+      parasInBlock = getParagraphBlock(note, firstSelLineIndex, config.includeFromStartOfSection, config.useTightBlockDefinition)
+      // Now attempt to highlight them to help user check all is well
+      const firstStartIndex = parasInBlock[0].contentRange.start
+      logDebug(pluginJson, firstStartIndex)
+      const lastStartIndex = parasInBlock[parasInBlock.length - 1].contentRange.start
+      logDebug(pluginJson, lastStartIndex)
+      const lastLength = parasInBlock[parasInBlock.length - 1].contentRange.length
+      logDebug(pluginJson, lastLength)
+      const lastEndIndex = parasInBlock[parasInBlock.length - 1].contentRange.end
+      logDebug(pluginJson, lastEndIndex)
+      // const parasCharIndexRange = { start: firstSelLineIndex, end: lastStartIndex + lastLength, length: lastStartIndex + lastLength - firstStartIndex }
+      const parasCharIndexRange: Range = { start: firstStartIndex, end: lastEndIndex - 1, length: lastEndIndex - firstStartIndex }
+      logDebug(pluginJson, `- highlighting automatic block selection range ${rangeToString(parasCharIndexRange)}`)
+      // FIXME: Waiting for Eduard to advise why this is failing with an Objective-C error
+      // Editor.highlightByRange(parasCharIndexRange)
+    }
+
+    // If this is a calendar note we've moving from, and the user wants to
+    // create a date backlink, then append backlink to the first selectedPara in parasInBlock
+    if (config.addDateBacklink && note.type === 'Calendar') {
+      const datePart: string =
+        (config.dateRefStyle === 'link') ? ` >${hyphenatedDate(new Date())}`
+          : (config.dateRefStyle === 'at') ? ` @${hyphenatedDate(new Date())}`
+            : (config.dateRefStyle === 'date') ? ` (${toLocaleDateTimeString(new Date())})`
+              : ''
+      parasInBlock[0].content = `${parasInBlock[0].content} ${datePart}`
+    }
+    // Note: When written, there was no API function to deal with multiple 
+    // selectedParagraphs, qbut we can insert a raw text string.
+    // (can't simply use note.addParagraphBelowHeadingTitle() as we have more options than it supports)
+    const selectedParasAsText = parasToText(parasInBlock)
+
+    // Decide where to move to
+    // Ask for the note we want to add the selectedParas
+    const notes = allNotesSortedByChanged()
+
+    const res = await CommandBar.showOptions(
+      notes.map((n) => n.title ?? 'untitled'),
+      `Select note to move ${parasInBlock.length} lines to`,
+    )
+    const destNote = notes[res.index]
+    // Note: showOptions returns the first item if something else is typed. And I can't see a way to distinguish between the two.
+    // logDebug(pluginJson, displayTitle(destNote)) // NB: -> first item in list (if a new item is typed)
+
+    // Ask to which heading to add the selectedParas
+    const headingToFind = (await chooseHeading(destNote, true, true, false))
+    logDebug(pluginJson, `- Moving to note: ${displayTitle(destNote)} under heading: '${headingToFind}'`)
+
+    // Add text to the new location in destination note
+    addParasAsText(destNote, selectedParasAsText, headingToFind, config.whereToAddInSection)
+
+    // delete from existing location
+    logDebug(pluginJson, `- Removing ${parasInBlock.length} paras from original note`)
+    note.removeParagraphs(parasInBlock)
   }
-
-  // Get config settings
-  const config = await getFilerSettings()
-
-  // Get current selection, and its range
-  const selection = Editor.selection
-  if (selection == null) {
-    logWarn(pluginJson, 'moveParas: No selection found, so stopping.')
-    return
+  catch (error) {
+    logError(pluginJson, error.message)
   }
-  // Get paragraph indexes for the start and end of the selection (can be the same)
-  const [firstSelParaIndex, lastSelParaIndex] = selectedLinesIndex(selection, paragraphs)
-  // Get paragraphs for the selection or block
-  const parasInBlock: Array<TParagraph> = (lastSelParaIndex !== firstSelParaIndex)
-    ? selectedParagraphs.slice()   // copy to avoid $ReadOnlyArray problem
-    : getParagraphBlock(note, firstSelParaIndex, config.useExtendedBlockDefinition)
-
-  // If this is a calendar note we've moving from, and the user wants to
-  // create a date backlink, then append backlink to the first selectedPara in parasInBlock
-  if (config.addDateBacklink && note.type === 'Calendar') {
-    const datePart: string = 
-        (config.dateLinkStyle === 'link') ? ` >${hyphenatedDate(new Date())}`
-        : (config.dateLinkStyle === 'at') ? ` @${hyphenatedDate(new Date())}`
-          : (config.dateLinkStyle === 'date') ? ` (${toLocaleDateTimeString(new Date())})`
-            : ''
-    parasInBlock[0].content = `${parasInBlock[0].content} ${datePart}`
-  }
-  // Note: When written, there was no API function to deal with multiple 
-  // selectedParagraphs, qbut we can insert a raw text string.
-  // (can't simply use note.addParagraphBelowHeadingTitle() as we have more options than it supports)
-  const selectedParasAsText = parasToText(parasInBlock)
-
-  // Decide where to move to
-  // Ask for the note we want to add the selectedParas
-  const notes = allNotesSortedByChanged()
-
-  const res = await CommandBar.showOptions(
-    notes.map((n) => n.title ?? 'untitled'),
-    `Select note to move ${parasInBlock.length} lines to`,
-  )
-  const destNote = notes[res.index]
-  // Note: showOptions returns the first item if something else is typed. And I can't see a way to distinguish between the two.
-  // logDebug(pluginJson, displayTitle(destNote)) // NB: -> first item in list (if a new item is typed)
-
-  // Ask to which heading to add the selectedParas
-  const headingToFind = (await chooseHeading(destNote, true, true, false))
-  // logDebug(pluginJson, `  Moving to note: ${displayTitle(destNote)} under heading: '${headingToFind}'`)
-
-  // Add text to the new location in destination note
-  addParasAsText(destNote, selectedParasAsText, headingToFind, config.whereToAddInSection)
-
-  // delete from existing location
-  logDebug(pluginJson, `Removing ${parasInBlock.length} paras from original note`)
-  note.removeParagraphs(parasInBlock)
 }
 
 /**
@@ -160,56 +190,59 @@ export async function moveParasToNextWeekly(): Promise<void> {
  * @param {Date} date of weekly note to move to
  */
 export async function moveParasToCalendarWeekly(destDate: Date): Promise<void> {
-  const { content, paragraphs, selectedParagraphs, note } = Editor
-  // Get config settings
-  const config = await getFilerSettings()
+  try {
+    const { content, paragraphs, selectedParagraphs, note } = Editor
+    // Get config settings
+    const config = await getFilerSettings()
 
-  // Pre-flight checks
-  if (content == null || selectedParagraphs == null || note == null) {
-    // No note open, or no selectedParagraph selection (perhaps empty note), so don't do anything.
-    logWarn(pluginJson, 'No note open, so stopping.')
-    return
-  }
-  if (NotePlan.environment.buildVersion < 801) {
+    // Pre-flight checks
+    if (content == null || selectedParagraphs == null || note == null) {
+      // No note open, or no selectedParagraph selection (perhaps empty note), so don't do anything.
+      logWarn(pluginJson, 'No note open, so stopping.')
+      return
+    }
     // Need to be running v3.6.0 (v802/801) or over for this feature
-    // TODO: change this to .versionString < "3.6.0" if Eduard changes the logic
-    await showMessage(`Sorry: you need to be running NotePlan v3.6.0 or higher for the Weekly note feature to work.`)
-    logWarn(pluginJson, 'Need to be running NotePlan v3.6.0 or higher for the Weekly note feature to work.')
-    return
+    if (NotePlan.environment.buildVersion < 801) {
+      await showMessage(`Sorry: you need to be running NotePlan v3.6.0 or higher for the Weekly note feature to work.`)
+      logWarn(pluginJson, 'Need to be running NotePlan v3.6.0 or higher for the Weekly note feature to work.')
+      return
+    }
+    // Find the Weekly note to move to
+    const destNote = DataStore.calendarNoteByDate(destDate, 'week')
+    if (destNote == null) {
+      await showMessage(`Sorry: I can't find the Weekly note for ${destDate.toLocaleDateString()}.`)
+      logError(pluginJson, `Failed to open the Weekly note for ${destDate.toLocaleDateString()}. Stopping.`)
+      return
+    }
+
+    // Get current selection, and its range
+    const selection = Editor.selection
+    if (selection == null) {
+      logError(pluginJson, 'No selection found, so stopping.')
+      return
+    }
+    // Get paragraph indexes for the start and end of the selection (can be the same)
+    const [firstSelParaIndex, lastSelParaIndex] = selectedLinesIndex(selection, paragraphs)
+    // Get paragraphs for the selection or block
+    const parasInBlock: Array<TParagraph> = (lastSelParaIndex !== firstSelParaIndex)
+      ? selectedParagraphs.slice()   // copy to avoid $ReadOnlyArray problem
+      : getParagraphBlock(note, firstSelParaIndex, config.includeFromStartOfSection, config.useTightBlockDefinition)
+
+    // At the time of writing, there's no API function to work on multiple selectedParagraphs,
+    // or one to insert an indented selectedParagraph, so we need to convert the selectedParagraphs
+    // to a raw text version which we can include
+    const selectedParasAsText = parasToText(parasInBlock)
+
+    // Append text to the new location in destination note
+    addParasAsText(destNote, selectedParasAsText, '', config.whereToAddInSection)
+
+    // delete from existing location
+    logDebug(pluginJson, `Removing ${parasInBlock.length} paras from original note`)
+    note.removeParagraphs(parasInBlock)
   }
-  // Find the Weekly note to move to
-  const destNote = DataStore.calendarNoteByDate(destDate, 'week')
-  if (destNote == null) {
-    // Need to be running v3.6.0 or over for this feature
-    await showMessage(`Sorry: I can't find the Weekly note for ${destDate.toLocaleDateString()}.`)
-    logError(pluginJson, `Failed to open the Weekly note for ${destDate.toLocaleDateString()}. Stopping.`)
-    return
+  catch (error) {
+    logError(pluginJson, error.message)
   }
-
-  // Get current selection, and its range
-  const selection = Editor.selection
-  if (selection == null) {
-    logError(pluginJson, 'No selection found, so stopping.')
-    return
-  }
-  // Get paragraph indexes for the start and end of the selection (can be the same)
-  const [firstSelParaIndex, lastSelParaIndex] = selectedLinesIndex(selection, paragraphs)
-  // Get paragraphs for the selection or block
-  const parasInBlock: Array<TParagraph> = (lastSelParaIndex !== firstSelParaIndex)
-    ? selectedParagraphs.slice()   // copy to avoid $ReadOnlyArray problem
-    : getParagraphBlock(note, firstSelParaIndex, config.useExtendedBlockDefinition)
-
-  // At the time of writing, there's no API function to work on multiple selectedParagraphs,
-  // or one to insert an indented selectedParagraph, so we need to convert the selectedParagraphs
-  // to a raw text version which we can include
-  const selectedParasAsText = parasToText(parasInBlock)
-
-  // Append text to the new location in destination note
-  addParasAsText(destNote, selectedParasAsText, '', config.whereToAddInSection)
-
-  // delete from existing location
-  logDebug(pluginJson, `Removing ${parasInBlock.length} paras from original note`)
-  note.removeParagraphs(parasInBlock)
 }
 
 /**
@@ -237,49 +270,53 @@ export async function moveParasToTomorrow(): Promise<void> {
  * @param {Date} date of daily note to move to
  */
 export async function moveParasToCalendarDate(destDate: Date): Promise<void> {
-  const { content, paragraphs, selectedParagraphs, note } = Editor
-  // Get config settings
-  const config = await getFilerSettings()
+  try {
+    const { content, paragraphs, selectedParagraphs, note } = Editor
+    // Get config settings
+    const config = await getFilerSettings()
 
-  // Pre-flight checks
-  if (content == null || selectedParagraphs == null || note == null) {
-    // No note open, or no selectedParagraph selection (perhaps empty note), so don't do anything.
-    logError(pluginJson, 'No note open, so stopping.')
-    return
+    // Pre-flight checks
+    if (content == null || selectedParagraphs == null || note == null) {
+      // No note open, or no selectedParagraph selection (perhaps empty note), so don't do anything.
+      logError(pluginJson, 'No note open, so stopping.')
+      return
+    }
+    // Find the Daily note to move to
+    const destNote = DataStore.calendarNoteByDate(destDate, 'day')
+    if (destNote == null) {
+      await showMessage(`Sorry: I can't find the Daily note for ${destDate.toLocaleDateString()}.`)
+      logError(pluginJson, `Failed to open the Daily note for ${destDate.toLocaleDateString()}. Stopping.`)
+      return
+    }
+
+    // Get current selection, and its range
+    const selection = Editor.selection
+    if (selection == null) {
+      logError(pluginJson, 'No selection found, so stopping.')
+      return
+    }
+    // Get paragraph indexes for the start and end of the selection (can be the same)
+    const [firstSelParaIndex, lastSelParaIndex] = selectedLinesIndex(selection, paragraphs)
+    // Get paragraphs for the selection or block
+    const parasInBlock: Array<TParagraph> = (lastSelParaIndex !== firstSelParaIndex)
+      ? selectedParagraphs.slice()   // copy to avoid $ReadOnlyArray problem
+      : getParagraphBlock(note, firstSelParaIndex, config.includeFromStartOfSection, config.useTightBlockDefinition)
+
+    // At the time of writing, there's no API function to work on multiple selectedParagraphs,
+    // or one to insert an indented selectedParagraph, so we need to convert the selectedParagraphs
+    // to a raw text version which we can include
+    const selectedParasAsText = parasToText(parasInBlock)
+
+    // Append text to the new location in destination note
+    addParasAsText(destNote, selectedParasAsText, '', config.whereToAddInSection)
+
+    // delete from existing location
+    logDebug(pluginJson, `Removing ${parasInBlock.length} paras from original note`)
+    note.removeParagraphs(parasInBlock)
   }
-  // Find the Daily note to move to
-  const destNote = DataStore.calendarNoteByDate(destDate, 'day')
-  if (destNote == null) {
-    // Need to be running v3.6.0 or over for this feature
-    await showMessage(`Sorry: I can't find the Daily note for ${destDate.toLocaleDateString()}.`)
-    logError(pluginJson, `Failed to open the Daily note for ${destDate.toLocaleDateString()}. Stopping.`)
-    return
+  catch (error) {
+    logError(pluginJson, error.message)
   }
-
-  // Get current selection, and its range
-  const selection = Editor.selection
-  if (selection == null) {
-    logError(pluginJson, 'No selection found, so stopping.')
-    return
-  }
-  // Get paragraph indexes for the start and end of the selection (can be the same)
-  const [firstSelParaIndex, lastSelParaIndex] = selectedLinesIndex(selection, paragraphs)
-  // Get paragraphs for the selection or block
-  const parasInBlock: Array<TParagraph> = (lastSelParaIndex !== firstSelParaIndex)
-    ? selectedParagraphs.slice()   // copy to avoid $ReadOnlyArray problem
-    : getParagraphBlock(note, firstSelParaIndex, config.useExtendedBlockDefinition)
-
-  // At the time of writing, there's no API function to work on multiple selectedParagraphs,
-  // or one to insert an indented selectedParagraph, so we need to convert the selectedParagraphs
-  // to a raw text version which we can include
-  const selectedParasAsText = parasToText(parasInBlock)
-
-  // Append text to the new location in destination note
-  addParasAsText(destNote, selectedParasAsText, '', config.whereToAddInSection)
-
-  // delete from existing location
-  logDebug(pluginJson, `Removing ${parasInBlock.length} paras from original note`)
-  note.removeParagraphs(parasInBlock)
 }
 
 

--- a/jgclark.Filer/src/fileItems.js
+++ b/jgclark.Filer/src/fileItems.js
@@ -2,7 +2,7 @@
 // ----------------------------------------------------------------------------
 // Plugin to help move selected Paragraphs to other notes
 // Jonathan Clark
-// last updated 4.8.2022 for v0.9.0
+// last updated 5.8.2022 for v0.9.0
 // ----------------------------------------------------------------------------
 
 import pluginJson from "../plugin.json"
@@ -107,17 +107,21 @@ export async function moveParas(): Promise<void> {
     } else {
       parasInBlock = getParagraphBlock(note, firstSelLineIndex, config.includeFromStartOfSection, config.useTightBlockDefinition)
       // Now attempt to highlight them to help user check all is well
+      // $FlowFixMe[incompatible-use]
       const firstStartIndex = parasInBlock[0].contentRange.start
-      logDebug(pluginJson, firstStartIndex)
+      // $FlowFixMe[incompatible-use]
       const lastStartIndex = parasInBlock[parasInBlock.length - 1].contentRange.start
-      logDebug(pluginJson, lastStartIndex)
+      // $FlowFixMe[incompatible-use]
       const lastLength = parasInBlock[parasInBlock.length - 1].contentRange.length
-      logDebug(pluginJson, lastLength)
+      // $FlowFixMe[incompatible-use]
       const lastEndIndex = parasInBlock[parasInBlock.length - 1].contentRange.end
-      logDebug(pluginJson, lastEndIndex)
-      // const parasCharIndexRange = { start: firstSelLineIndex, end: lastStartIndex + lastLength, length: lastStartIndex + lastLength - firstStartIndex }
+      // logDebug(pluginJson, firstStartIndex)
+      // logDebug(pluginJson, lastStartIndex)
+      // logDebug(pluginJson, lastLength)
+      // logDebug(pluginJson, lastEndIndex)
+      // const parasCharIndexRange = { start: firstStartIndex, end: lastStartIndex + lastLength, length: lastStartIndex + lastLength - firstStartIndex }
       const parasCharIndexRange: Range = { start: firstStartIndex, end: lastEndIndex - 1, length: lastEndIndex - firstStartIndex }
-      logDebug(pluginJson, `- highlighting automatic block selection range ${rangeToString(parasCharIndexRange)}`)
+      logDebug(pluginJson, `- will try to highlight automatic block selection range ${rangeToString(parasCharIndexRange)}`)
       // FIXME: Waiting for Eduard to advise why this is failing with an Objective-C error
       // Editor.highlightByRange(parasCharIndexRange)
     }

--- a/jgclark.Filer/src/newNote.js
+++ b/jgclark.Filer/src/newNote.js
@@ -3,7 +3,7 @@
 // @dwertheimer based on @jgclark's newNote
 // Create new note from currently selected text
 // and (optionally) leave backlink to it where selection was
-// Last updated 27.6.2022 for 0.8.1, @jgclark
+// Last updated 4.8.2022 for 0.8.1+, @jgclark
 //-----------------------------------------------------------------------------
 
 import pluginJson from '../plugin.json'
@@ -20,7 +20,7 @@ export async function newNoteFromClipboard(): Promise<void> {
   const { string } = Clipboard
 
   if (string != null && string.length > 0) {
-    logDebug(pluginJson, `  starting: have ${string.length} characters in clipboard`)
+    logDebug(pluginJson, `newNoteFromClipboard() starting: have ${string.length} characters in clipboard`)
 
     // Get title for this note
     // Offer the first line to use, shorn of any leading # marks
@@ -63,11 +63,11 @@ export async function newNoteFromSelection(): Promise<void> {
   const { selectedLinesText, selectedText, selectedParagraphs, note } = Editor
 
   if (note != null && selectedLinesText.length && selectedText !== '') {
-    logDebug(pluginJson, `  with ${selectedParagraphs.length} selected:`)
+    logDebug(pluginJson, `newNoteFromSelection() starting with ${selectedParagraphs.length} selected:`)
     const selectedLinesTextToMutate = selectedLinesText.slice() // copy that we can change
 
     // Get title for this note
-    const isTextContent = ['title', 'text', 'empty'].indexOf(selectedParagraphs[0].type) >= 0
+    const isTextContent = ['title', 'text'].indexOf(selectedParagraphs[0].type) >= 0
     const strippedFirstLine = selectedParagraphs[0].content
     let title = await getInput('Title of new note', 'OK', 'New Note from Selection', strippedFirstLine)
     if (typeof title === 'string') {
@@ -86,21 +86,20 @@ export async function newNoteFromSelection(): Promise<void> {
       if (title) {
         // Create new note in the specific folder
         const origFile = displayTitle(note) // Calendar notes have no title, so need to make one
-        logDebug(pluginJson, `origFile: ${origFile}`)
+        logDebug(pluginJson, `- origFile: ${origFile}`)
         const filename = (await DataStore.newNote(title, currentFolder)) ?? ''
-        logDebug(pluginJson, `newNote() -> filename: ${filename}`)
+        logDebug(pluginJson, `- newNote() -> filename: ${filename}`)
 
         // This question needs to be here after newNote and before noteOpener
-        // to force a cache refresh after newNote. This API bug will eventually be fixed.
-        // TODO: Check if this bug has been fixed (I think it has).
+        // to force a cache refresh after newNote.
+        // Note: This API bug has probably now been fixed.
         const iblq = await CommandBar.showOptions(['Yes', 'No'], 'Insert link to new file where selection was?')
 
         const newNote = await noteOpener(filename, 'using filename')
 
         if (newNote) {
-          // logDebug(pluginJson, `newNote's title: ${String(newNote.title)}`)
-          // logDebug(pluginJson, `newNote's content: ${String(newNote.content)} ...`)
-
+          logDebug(pluginJson, `- newNote's title: ${String(newNote.title)}`)
+          logDebug(pluginJson, `- newNote's content: ${String(newNote.content)} ...`)
           const insertBackLink = iblq.index === 0
           // $FlowFixMe[method-unbinding] - Flow thinks the function is being removed from the object, but it's not
           if (Editor.replaceSelectionWithText) {
@@ -130,7 +129,7 @@ export async function newNoteFromSelection(): Promise<void> {
       logWarn(pluginJson, 'The user cancelled the operation.')
     }
   } else {
-    logDebug(pluginJson, 'No text was selected, so nothing to do.')
+    logDebug(pluginJson, '- No text was selected, so nothing to do.')
     showMessage('No text was selected, so nothing to do.', "OK, I'll try again", `New Note from Selection`)
   }
 }


### PR DESCRIPTION
Pls see discussion: https://discord.com/channels/763107030223290449/1004560263627944016/1004560265330835477

Pasted for posterity:

dwertheimer — Today at 6:23 PM
@jgclark Question for you. I have a "block" like this:
## [Events to Add to Calendar](noteplan://x-callback-url/runPlugin?pluginID=dwertheimer.EventAutomations&command=cevt%20-%20Create%20Events%20From%20Text&arg0=Events%20to%20Add%20to%20Calendar)
Pick up Pierce at 5pm
Take Anique to Wells Fargo/Cava at 3pm
Cancelled: Tennis with Tomer at 6pm

When I call getParagraphBlock(), I get all but the last line.
I looked at the code, and I see why.
  const endOfActiveSection = findEndOfActivePartOfNote(note)

In my case, note.paragraphs[endOfActiveSection].content is equal to the last paragraph in my block. 
So far so good.
But the for loop does this:
    for (let i = startLine + 1; i < endOfActiveSection; i++) {
Note the i < endOfActiveSection
Feels to me like this should be i <= 
That works for me, but I don't know if that will mess up other places you've been happily using this code. So I don't want to push the change.
Also there's another loop which maybe needs adjusting as well.
    // See if there are following indented lines to move as well
    for (let i = startLine + 1; i < endOfActiveSection; i++) {
Can you please have a look and see if you can address it without having some negative consequence for the way you use the code?