### PR TITLE
EventHelpers: Add new `includeAllDayEvents` parameter

### DIFF
--- a/jgclark.EventHelpers/CHANGELOG.md
+++ b/jgclark.EventHelpers/CHANGELOG.md
@@ -1,7 +1,7 @@
 # What's changed in 🕓 Event Helpers?
 See [website README for more details](https://github.com/NotePlan/plugins/tree/main/jgclark.EventHelpers), and how to configure.
 
-## [0.17.1] - 2022-08-30
+## [0.17.1] - 2022-08-31
 ### Changed
 - the format of `*|DATE|*` can now be overridden with the 'Shared Settings > Locale' setting.
 

--- a/jgclark.EventHelpers/CHANGELOG.md
+++ b/jgclark.EventHelpers/CHANGELOG.md
@@ -1,6 +1,10 @@
 # What's changed in 🕓 Event Helpers?
 See [website README for more details](https://github.com/NotePlan/plugins/tree/main/jgclark.EventHelpers), and how to configure.
 
+## [0.17.1] - 2022-08-30
+### Changed
+- the format of `*|DATE|*` can now be overridden with the 'Shared Settings > Locale' setting.
+
 ## [0.17.0] - 2022-08-10
 ### Added
 - the **location** of an event is now available in the output of "/insert day's event as list" and "/insert matching events" commands. It's formatting code is `*|LOCATION|*`.

--- a/jgclark.EventHelpers/CHANGELOG.md
+++ b/jgclark.EventHelpers/CHANGELOG.md
@@ -1,6 +1,10 @@
 # What's changed in 🕓 Event Helpers?
 See [website README for more details](https://github.com/NotePlan/plugins/tree/main/jgclark.EventHelpers), and how to configure.
 
+## [0.18.0] - 2022-08-31
+### Added
+- new `includeAllDayEvents` parameter for the `events()` and `matchingEvents()` template functions.
+
 ## [0.17.1] - 2022-08-31
 ### Changed
 - the format of `*|DATE|*` can now be overridden with the 'Shared Settings > Locale' setting.

--- a/jgclark.EventHelpers/README.md
+++ b/jgclark.EventHelpers/README.md
@@ -95,6 +95,8 @@ v0.15.0 added more flexibility in the formatting of event lists. So now instead 
 
 If you want to disable the adding of the heading, add the following parameter `includeHeadings:false` (no double quotes around `false` as its being treated as JSON).
 
+If you want to exclude all-day events, add the following parameter `includeAllDayEvents:false` (no double quotes around `false` as its being treated as JSON).
+
 For example:
 
 ```js

--- a/jgclark.EventHelpers/README.md
+++ b/jgclark.EventHelpers/README.md
@@ -88,6 +88,7 @@ You can place  `<%- listMatchingEvents() %>` in Templates in a similar way, and 
 Most of these are self-explanatory for events in most types of calendars, other than:
 - `*|ATTENDEES|*` gives the full details of event attendees provided by the operating system, and can be a mix of names, email addresses, and other details;
 - `*|ATTENDEENAMES|*` just gives the name of event attendees, or if that's missing, just the email address;
+- `*|DATE|*` is formatted using the locale settings from your operating system, unless you override that with the 'Shared Settings > Locale' setting.
 - `*|EVENTLINK|*` is specific to NotePlan: it will make a nicely-formatted link to the actual calendar event, and clicking on it will show a pop with all the event's details.
 
 v0.15.0 added more flexibility in the formatting of event lists. So now instead of including (for example) `*|ATTENDEENAMES|*` you can now include other text (including line breaks indicated by `\n`) within the placeholder. For example in `*|\nwith ATTENDEENAMES|*` if the ATTENDEENAMES is not empty, then it will output the list after a newline and the text 'with '.

--- a/jgclark.EventHelpers/__tests__/eventsToNotes.test.js
+++ b/jgclark.EventHelpers/__tests__/eventsToNotes.test.js
@@ -58,15 +58,16 @@ describe('eventsToNotes.js tests', () => {
     // This function's tests use $Shape<...> to use a subset of large objects without causing errors
     const config: $Shape<EventsConfig> = {
       calendarNameMappings: [],
-      locale: "en-GB",
+      locale: "se-SE",
       timeOptions: ""
     }
     const format1 = "- (*|CAL|*) *|TITLE|**| URL|**|\n> NOTES|*\n*|ATTENDEES|*" // simpler
     const format2 = "### (*|CAL, |**|START|**|-END|*) *|TITLE|**|\nEVENTLINK|**| URL|**| with ATTENDEENAMES|**|\n> NOTES|*\n---\n" // more complex
     const format3 = "### [*|START|*] *|TITLE|*\n- \n \n*****\n" // for @EasyTarget test
     const format4 = "### [*|START|*] *|TITLE|*\n- \n\n\n\n\n" // for @EasyTarget test
-    const startDT = new Date(2021, 0, 1, 20, 0, 0)
-    const endDT = new Date(2021, 0, 1, 22, 0, 0)
+    const format5 = "- *|DATE|*" // date formatting using configured locale
+    const startDT = new Date(2021, 0, 23, 20, 0, 0)
+    const endDT = new Date(2021, 0, 23, 22, 0, 0)
     const attendeesArray: Array<string> = ["✓ Jonathan Clark", "? James Bond", "x Martha", "? bob@example.com"]
     const attendeeNamesArray: Array<string> = ["Jonathan Clark", "Martha Clark", "bob@example.com"]
     const event1: $Shape<TCalendarItem> = { calendar: 'Jonathan', title: 'title of event1', url: 'https://example.com/easy', date: startDT, endDate: endDT, notes: 'a few notes', attendees: attendeesArray, attendeeNames: attendeeNamesArray } // simple case
@@ -109,6 +110,11 @@ describe('eventsToNotes.js tests', () => {
       console.log(expected.length)
       expect(result).toEqual(expected)
     })
+    test('event 1 format 5 date test', () => {
+      const result = e.smartStringReplace(format5, replacements1)
+      expect(result).toEqual('- 2021-01-23')
+    })
+
 
   })
 

--- a/jgclark.EventHelpers/plugin.json
+++ b/jgclark.EventHelpers/plugin.json
@@ -8,8 +8,8 @@
   "plugin.author": "jgclark",
   "plugin.url": "https://github.com/NotePlan/plugins/tree/main/jgclark.EventHelpers",
   "plugin.changelog": "https://github.com/NotePlan/plugins/tree/main/jgclark.EventHelpers/CHANGELOG.md",
-  "plugin.version": "0.17.0",
-  "plugin.lastUpdateInfo": "Add support for LOCATION in events, and for adding nicely-formmatted event links rather than eventIDs.",
+  "plugin.version": "0.17.1",
+  "plugin.lastUpdateInfo": "DATE can now be overridden with the 'Shared Settings > Locale' setting",
   "plugin.dependencies": [],
   "plugin.script": "script.js",
   "plugin.isRemote": "false",
@@ -211,7 +211,7 @@
     {
       "key": "locale",
       "title": "Locale",
-      "description": "Optional Locale to use for times in events. If not given, will default to what the OS reports, or failing that, 'en-US'.",
+      "description": "Optional Locale to use for the date and times in events. If not given, will default to what the OS reports, or failing that, 'en-US'.",
       "type": "string",
       "default": "",
       "required": false

--- a/jgclark.EventHelpers/src/eventsToNotes.js
+++ b/jgclark.EventHelpers/src/eventsToNotes.js
@@ -54,6 +54,7 @@ export async function listDaysEvents(paramString: string = ''): Promise<string> 
       : (paramString.includes('"allday_template":'))
         ? String(await getTagParamsFromString(paramString, 'allday_template', '- *|CAL|*: *|TITLE|**| with ATTENDEENAMES|**|\nLOCATION|**|\nNOTES|**|\nURL|*'))
         : config.formatAllDayEventsDisplay
+    const includeAllDayEvents: boolean = await getTagParamsFromString(paramString, 'includeAllDayEvents', true)
     const includeHeadings = await getTagParamsFromString(paramString, 'includeHeadings', true)
     const daysToCover: number = await getTagParamsFromString(paramString, 'daysToCover', 1)
     // If the format contains 'CAL' then we care about calendar names in output
@@ -86,6 +87,11 @@ export async function listDaysEvents(paramString: string = ''): Promise<string> 
       // Process each event
       for (const e of eArr) {
         logDebug(pluginJson, `  Processing event '${e.title}' (${typeof e})`)
+        if (!includeAllDayEvents && e.isAllDay) {
+          logDebug(pluginJson, `    skipping as event is all day and includeAllDayEvents is false`)
+          continue
+        }
+  
         // Replace any mentions of the keywords in the e.title string
         const replacements = getReplacements(e, config)
         const thisEventStr = smartStringReplace(e.isAllDay ? alldayformat : format, replacements)
@@ -168,6 +174,7 @@ export async function listMatchingDaysEvents(
   logDebug(pluginJson, `From settings found ${textToMatchArr.length} match strings to look for`)
 
   // Get a couple of other supplied parameters, or use defaults
+  const includeAllDayEvents: boolean = await getTagParamsFromString(paramString, 'includeAllDayEvents', true)
   const includeHeadings = await getTagParamsFromString(paramString, 'includeHeadings', true)
   const daysToCover: number = await getTagParamsFromString(paramString, 'daysToCover', 1)
 
@@ -195,6 +202,10 @@ export async function listMatchingDaysEvents(
 
     // for each event, check each of the strings we want to match
     for (const e of eArr) {
+      if (!includeAllDayEvents && e.isAllDay) {
+        continue
+      }
+
       for (let j = 0; j < textToMatchArr.length; j++) {
         const thisFormat: string = String(formatArr[j])
         const withCalendarName = thisFormat.includes('CAL')

--- a/jgclark.EventHelpers/src/eventsToNotes.js
+++ b/jgclark.EventHelpers/src/eventsToNotes.js
@@ -1,8 +1,8 @@
 // @flow
 // ----------------------------------------------------------------------------
 // Command to bring calendar events into notes
-// Last updated 10.8.2022 for v0.16.7, by @jgclark
-// @jgclark, with additions by @dwertheimer, @weyert, @m1well
+// Last updated 30.8.2022 for v0.17.1, by @akrabat
+// @jgclark, with additions by @dwertheimer, @weyert, @m1well, @akrabat
 // ----------------------------------------------------------------------------
 
 import pluginJson from "../plugin.json"
@@ -275,7 +275,7 @@ export function getReplacements(item: TCalendarItem, config: EventsConfig): Map<
   outputObject.set('ATTENDEES', item.attendees ? item.attendees.join(', ') : '')
   outputObject.set('EVENTLINK', item.calendarItemLink ? item.calendarItemLink : '')
   outputObject.set('LOCATION', item.location ? item.location : '')
-  outputObject.set('DATE', toLocaleDateString(item.date))
+  outputObject.set('DATE', toLocaleDateString(item.date, config.locale))
   outputObject.set('START', !item.isAllDay ? toLocaleTime(item.date, config.locale, config.timeOptions) : '')
   outputObject.set('END', item.endDate != null && !item.isAllDay ? toLocaleTime(item.endDate, config.locale, config.timeOptions) : '')
   outputObject.set('URL', item.url)


### PR DESCRIPTION
In both `events()` and `matchingEvents()`, support a new `includeAllDayEvents` boolean parameter to allow disabling the display of all day events by setting to `false`. Default is `true`.

Note that I expect this PR to be merged after #337 as it is branched off that PR's branch.