### PR TITLE
Readwise: 0.1.1

### DIFF
--- a/aaronpoweruser.ReadwiseUnofficial/CHANGELOG.md
+++ b/aaronpoweruser.ReadwiseUnofficial/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 See Plugin [README](https://github.com/NotePlan/plugins/blob/main/aaronpoweruser.ReadwiseUnofficial/README.md) for details on available commands and use case.
 
+## [0.1.1] - 2022-12-29 (aaronpoweruser)
+
+- Enabled only syncing new highlights (added a hidden setting to override)
+- Clean up plugin settings description
+- Only add metadata once (need to handle tag updates)
+- Add link to kindle for books (fixes links being null)
 ## [0.1.0] - 2022-12-28 (aaronpoweruser)
 
 ### Added

--- a/aaronpoweruser.ReadwiseUnofficial/CHANGELOG.md
+++ b/aaronpoweruser.ReadwiseUnofficial/CHANGELOG.md
@@ -10,16 +10,9 @@ See Plugin [README](https://github.com/NotePlan/plugins/blob/main/aaronpoweruser
 - Clean up plugin settings description
 - Only add metadata once (need to handle tag updates)
 - Add link to kindle for books (fixes links being null)
+
 ## [0.1.0] - 2022-12-28 (aaronpoweruser)
-
-### Added
-List what has been added. If nothing has been changed, this section can be removed.
-
-### Changed
-List what has changed. If nothing has been changed, this section can be removed.
-
-### Removed
-List what has removed. If nothing has been removed, this section can be removed.
+First release
 
 ## Changelog
 

--- a/aaronpoweruser.ReadwiseUnofficial/README.md
+++ b/aaronpoweruser.ReadwiseUnofficial/README.md
@@ -15,7 +15,7 @@ A sync engine for readwise
 - Group be content type
 - Set download folder
 ### Todo
-* Image support
+* Image support (needs Noteplan API update)
 * Callback url to refresh notes
 * Ability to get random note via templates
 * Convert metadata to front matter

--- a/aaronpoweruser.ReadwiseUnofficial/plugin.json
+++ b/aaronpoweruser.ReadwiseUnofficial/plugin.json
@@ -4,8 +4,8 @@
   "noteplan.minAppVersion": "3.4.0",
   "plugin.id": "aaronpoweruser.ReadwiseUnofficial",
   "plugin.name": "📚 Readwise Unofficial",
-  "plugin.version": "0.1.0",
-  "plugin.lastUpdateInfo": "First release",
+  "plugin.version": "0.1.1",
+  "plugin.lastUpdateInfo": "Minor bugfixes: Fixed linking in book highlihts, clearified descriptions",
   "plugin.description": "A sync plugin for Readwise",
   "plugin.author": "aaronpoweruser",
   "plugin.dependencies": [],
@@ -49,16 +49,25 @@
       "title": "Folder name",
       "key": "baseFolder",
       "type": "string",
-      "description": "Enter some string and see it change when the plugin is run",
-      "default": "This default setting was set in plugin preferences!"
+      "description": "The folder name to store all highlights in",
+      "default": "Readwise"
     },
     {
       "COMMENT": "TODO: This should be a bool but doesn't work",
       "title": "Group by type",
       "key": "groupByType",
       "type": "string",
-      "description": "Group all highlights in under the readwise folder or having them separated by content type ie readwise/books, readwise/articles.ß",
-      "default": "true",
+      "description": "Group all highlights in under the readwise folder or having them separated by content type ie readwise/books, readwise/articles.",
+      "default": "false",
+      "required": false
+    },
+    {
+      "COMMENT": "Enable to force resynching of all highlights",
+      "title": "Force sync all highlights",
+      "key": "forceSync",
+      "type": "hidden",
+      "description": "Debug setting to always recreate all highlights",
+      "default": "false",
       "required": false
     },
     {

--- a/aaronpoweruser.ReadwiseUnofficial/src/NPReadwise.js
+++ b/aaronpoweruser.ReadwiseUnofficial/src/NPReadwise.js
@@ -72,10 +72,8 @@ async function parseBookAndWriteToNote(source) {
     log(pluginJson, `base folder is : ${baseFolder}`)
     const outputNote = await getOrMakeNote(title, baseFolder, '')
 
-    const now = new Date()
-    const createdDate = new Date(outputNote.createdDate)
     // Find a better way to check if the note is new
-    if (now - createdDate < 1000) {
+    if (new Date() - new Date(outputNote.createdDate) < 1000) {
       outputNote.addParagraphBelowHeadingTitle(metadata, 'text', 'Metadata', true, true)
     }
 

--- a/aaronpoweruser.ReadwiseUnofficial/src/NPReadwise.js
+++ b/aaronpoweruser.ReadwiseUnofficial/src/NPReadwise.js
@@ -73,7 +73,7 @@ async function parseBookAndWriteToNote(source) {
     const outputNote = await getOrMakeNote(title, baseFolder, '')
 
     // Find a better way to check if the note is new
-    if (new Date() - new Date(outputNote.createdDate) < 1000) {
+    if (new Date() - new Date(outputNote?.createdDate) < 1000) {
       outputNote.addParagraphBelowHeadingTitle(metadata, 'text', 'Metadata', true, true)
     }
 

--- a/aaronpoweruser.ReadwiseUnofficial/src/NPReadwise.js
+++ b/aaronpoweruser.ReadwiseUnofficial/src/NPReadwise.js
@@ -45,7 +45,10 @@ async function getReadwise(): Promise<any> {
     const response = await fetch(url, options)
     DataStore.saveData(new Date().toISOString(), LAST_SYNÇ_TIME, true)
 
-    return JSON.parse(response).results
+    const Json = JSON.parse(response)
+    log(pluginJson, `Downloaded : ${Json.count} highlights`)
+    
+    return Json.results
   } catch (error) {
     logError(pluginJson, error)
   }

--- a/aaronpoweruser.ReadwiseUnofficial/src/NPReadwise.js
+++ b/aaronpoweruser.ReadwiseUnofficial/src/NPReadwise.js
@@ -1,34 +1,36 @@
 // @flow
-import { insertContentUnderHeading } from "../../helpers/NPParagraph"
-import { showMessage } from "../../helpers/userInput";
+import { showMessage } from '../../helpers/userInput'
 import pluginJson from '../plugin.json'
 import { log, logDebug, logError, logWarn, clo, JSP } from '@helpers/dev'
 import { getOrMakeNote } from '@helpers/note'
 
+const READWISE_API_KEY_LENGTH = 50
+const LAST_SYNÇ_TIME = 'last_sync_time'
+
 // This is the main function that will be called by NotePlan
 export async function readwiseSync(): Promise<void> {
-  const settings = DataStore.settings
-  const accessToken = settings.accessToken ?? ''
+  const accessToken = DataStore.settings.accessToken ?? ''
   logDebug(pluginJson, `access token is : ${accessToken}`)
 
   if (accessToken === '') {
     showMessage(pluginJson, 'No access token found. Please add your Readwise access token in the plugin settings.')
     return
-  } else if (accessToken.length !== 50) {
+  } else if (accessToken.length !== READWISE_API_KEY_LENGTH) {
     showMessage(pluginJson, 'Invalid access token. Please check your Readwise access token in the plugin settings.')
     return
   }
 
   const response = await getReadwise()
-  response.map(parseBook)
+  response.map(parseBookAndWriteToNote)
 }
 
 // Downloads readwise data
 async function getReadwise(): Promise<any> {
   const accessToken = DataStore.settings.accessToken ?? ''
-  // TODO: Uncomment before merge
-  // const lastFetchTime = DataStore.loadData('last_sync_time', true) ?? ''
-  const lastFetchTime = ''
+  let lastFetchTime = DataStore.loadData(LAST_SYNÇ_TIME, true) ?? ''
+  if (DataStore.settings.forceSync === 'true') {
+    lastFetchTime = ''
+  }
   log(pluginJson, `last fetch time is : ${lastFetchTime}`)
 
   try {
@@ -37,27 +39,27 @@ async function getReadwise(): Promise<any> {
     const options = {
       method: 'GET',
       headers: {
-        'Authorization': `token ${ accessToken}`,
+        Authorization: `token ${accessToken}`,
       },
     }
     const response = await fetch(url, options)
-    DataStore.saveData(new Date().toISOString(), "last_sync_time", true)
- 
+    DataStore.saveData(new Date().toISOString(), LAST_SYNÇ_TIME, true)
+
     return JSON.parse(response).results
   } catch (error) {
     logError(pluginJson, error)
   }
 }
 
-async function parseBook(source) {
+async function parseBookAndWriteToNote(source) {
   try {
     const title = source.readable_title
     const author = source.author
     const category = source.category
     const highlights = source.highlights
-    let metadata = `author: [[${author}]]` + '\n' + `Category: [[${category}]]` + '\n'
+    let metadata = `author: [[${author}]]` + '\n' // + `Category: [[${category}]]` + '\n'
     if (source.book_tags !== null) {
-      metadata += `Document tags: ${source.book_tags.map(tag => `#${tag.name} `).join(', ')}\n`
+      metadata += `Document tags: ${source.book_tags.map((tag) => `#${tag.name} `).join(', ')}\n`
     }
     if (source.unique_url !== null) {
       metadata += `URL: ${source.unique_url}`
@@ -69,18 +71,27 @@ async function parseBook(source) {
     }
     log(pluginJson, `base folder is : ${baseFolder}`)
     const outputNote = await getOrMakeNote(title, baseFolder, '')
-    // TODO: This is adding empty newlines to the note need to fix.
-    await insertContentUnderHeading(outputNote, 'Highlights', '', 2)
-    // Probably shouldn't depend on this sorting and order by hand
-    await insertContentUnderHeading(outputNote, 'Metadata', metadata, 2)
-    highlights.map(highlight => appendToNote(highlight, outputNote))
+
+    const now = new Date()
+    const createdDate = new Date(outputNote.createdDate)
+    // Find a better way to check if the note is new
+    if (now - createdDate < 1000) {
+      outputNote.addParagraphBelowHeadingTitle(metadata, 'text', 'Metadata', true, true)
+    }
+
+    highlights.map((highlight) => appendHighlightToNote(outputNote, highlight, source.asin))
   } catch (error) {
-      logError(pluginJson, error)
+    logError(pluginJson, error)
   }
 }
 
-function appendToNote(highlight, note) {
+function appendHighlightToNote(note, highlight, asin = '') {
   const content = highlight.text
-  const formatedUrl = ` [View highlight](${highlight.url})`
+  let formatedUrl = ''
+  if (highlight.url !== null) {
+    formatedUrl = ` [View highlight](${highlight.url})`
+  } else if (asin !== '') {
+    formatedUrl = ` [Location ${highlight.location}](https://readwise.io/to_kindle?action=open&asin=${asin}&location=${highlight.location})`
+  }
   note.appendParagraph(content + formatedUrl, 'list')
 }


### PR DESCRIPTION
- Enabled only syncing new highlights (added a hidden setting to override)
- Clean up plugin settings description
- Only add metadata once (need to handle tag updates)
- Add link to kindle for books (fixes links being null)
- Remove content tag
