### PR TITLE
jgclark.Reviews speed improvements

### DIFF
--- a/helpers/NPnote.js
+++ b/helpers/NPnote.js
@@ -338,6 +338,7 @@ export function getNoteTitleFromFilename(filename: string, makeLink?: boolean = 
  * @param {boolean?} includeSubfolders - if folder given, whether to look in subfolders of this folder or not (optional, defaults to false)
  * @param {string?} tagToExclude - optional tag that if found in the note, excludes the note
  * @param {boolean?} caseInsensitiveMatch - whether to ignore case when matching (default true)
+ * @param {Array<TNote>?} notesToSearchIn - optional array of notes to search in
  * @return {Array<TNote>}
  */
 export function findNotesMatchingHashtag(

--- a/helpers/__tests__/folders.test.js
+++ b/helpers/__tests__/folders.test.js
@@ -51,7 +51,7 @@ describe('helpers/folders', () => {
       expect(folders.length).toBe(7)
     })
     test('Subfolder exclusion not matching -> 9 left', () => {
-      const exclusions = ['TEST/TEST LEVEL 3']
+      const exclusions = ['TEST/NOT IN LIST']
       const folders = Object.keys(f.getFilteredFolderList(exclusions))
       expect(folders.length).toBe(9)
     })

--- a/helpers/folders.js
+++ b/helpers/folders.js
@@ -19,8 +19,11 @@ export function getFilteredFolderList(exclusions: Array<string>, excludeSpecialF
   try {
     // Get all folders as array of strings (other than @Trash).
     const fullFolderList = DataStore.folders
-    let reducedList: Array<string> = fullFolderList.slice() // to avoid read-only flow error
-    logDebug('folders / filteredFolderList', `Starting to filter the ${fullFolderList.length} DataStore.folders with inclusions [${inclusions.toString()}] exclusions [${exclusions.toString()}]`)
+    // let reducedList: Array<string> = fullFolderList.slice() // to avoid read-only flow error
+    // logDebug(
+    //   'folders / filteredFolderList',
+    //   `Starting to filter the ${fullFolderList.length} DataStore.folders with inclusions [${inclusions.toString()}] exclusions [${exclusions.toString()}]`,
+    // )
 
     // const inclusionsTerminatedWithSlash: Array<string> = []
     // for (const e of inclusions) {
@@ -30,25 +33,28 @@ export function getFilteredFolderList(exclusions: Array<string>, excludeSpecialF
     for (const e of exclusions) {
       exclusionsTerminatedWithSlash.push(e.endsWith('/') ? e : `${e}/`)
     }
-    // const folderListTerminatedWithSlash: Array<string> = []
-    // for (const f of fullFolderList) {
-    //   folderListTerminatedWithSlash.push(f.endsWith('/') ? f : `${f}/`)
-    // }
+    let reducedList: Array<string> = []
+    for (const f of fullFolderList) {
+      reducedList.push(f.endsWith('/') ? f : `${f}/`)
+    }
 
     // filter reducedList to only folders that (string) contains an item in the inclusions list
     reducedList = inclusions.length ? reducedList.filter((folder) => inclusions.some((ff) => folder.includes(ff))) : reducedList
-    // logDebug('after inclusions', reducedList.toString())
+    // logDebug(`after inclusions: ${reducedList.length} folders: `, `${reducedList.toString()}\n`)
 
     // filter reducedList to only folders that don't start with an item in the exclusionsTerminatedWithSlash list
     reducedList = exclusionsTerminatedWithSlash.length ? reducedList.filter((folder) => !exclusionsTerminatedWithSlash.some((ee) => folder.startsWith(ee))) : reducedList
-    // logDebug('after exclusions', reducedList.toString())
+    // logDebug(`after exclusions: ${reducedList.length} folders: `, `${reducedList.toString()}\n`)
 
     // filter reducedList to only folders that don't start with the character '@' (special folders)
     reducedList = excludeSpecialFolders ? reducedList.filter((folder) => !folder.startsWith('@')) : reducedList
     // logDebug('after @', reducedList.toString())
 
-    logDebug('folders / filteredFolderList', `-> filteredList ${reducedList.length}: [${reducedList.toString()}]`)
-    return reducedList
+    // logDebug('folders / filteredFolderList', `-> filteredList: ${reducedList.length} items: [${reducedList.toString()}]`)
+    // return the array of folders, but if the last character is a slash, remove it
+    return reducedList.map((folder) => (folder.endsWith('/') ? folder.slice(0, -1) : folder))
+
+    // return reducedList
   } catch (error) {
     logError('folders/getFilteredFolderList', JSP(error))
     return ['(error)']

--- a/jgclark.Reviews/plugin.json
+++ b/jgclark.Reviews/plugin.json
@@ -8,8 +8,8 @@
   "plugin.author": "Jonathan Clark",
   "plugin.url": "https://github.com/NotePlan/plugins/tree/main/jgclark.Reviews",
   "plugin.changelog": "https://github.com/NotePlan/plugins/blob/main/jgclark.Reviews/CHANGELOG.md",
-  "plugin.version": "0.10.1",
-  "plugin.lastUpdateInfo": "0.10.1: bugfix\n0.10.0: new setting 'Folders to use in reviews' and fix @reviewed() duplication.\n0.9.5: small fixes.\n0.9.4: fixes and smarter window management.\n0.9.3: fixes.\n0.9.2: date fixes, locale language used where possible, tool tips & other polish.",
+  "plugin.version": "0.10.2",
+  "plugin.lastUpdateInfo": "0.11.0: introduce optional @nextReview() date, and skip next review function.\n0.10.2: further speed improvements.\n0.10.1: bugfix and more flexible 'Folders to Include' setting.\n0.10.0: new setting 'Folders to Include' and fix @reviewed() duplication.\n0.9.5: small fixes.\n0.9.4: fixes and smarter window management.\n0.9.3: fixes.\n0.9.2: date fixes, locale language used where possible, tool tips & other polish.",
   "plugin.requiredFiles": [],
   "plugin.requiredSharedFiles": [
     "fontawesome.css",
@@ -290,7 +290,7 @@
     {
       "key": "startMentionStr",
       "title": "Project start string",
-      "description": "@string indicating date a project/area was started (default: @start)",
+      "description": "@string indicating date a project/area was started (default: '@start')",
       "type": "string",
       "default": "@start",
       "required": true
@@ -298,7 +298,7 @@
     {
       "key": "completedMentionStr",
       "title": "Project completed string",
-      "description": "@string indicating date a project/area was completed (default: @completed)",
+      "description": "@string indicating date a project/area was completed (default: '@completed')",
       "type": "string",
       "default": "@completed",
       "required": true
@@ -306,7 +306,7 @@
     {
       "key": "cancelledMentionStr",
       "title": "Project cancelled string",
-      "description": "@string indicating date a project/area was cancelled (default: @cancelled)",
+      "description": "@string indicating date a project/area was cancelled (default: '@cancelled')",
       "type": "string",
       "default": "@cancelled",
       "required": true
@@ -314,7 +314,7 @@
     {
       "key": "dueMentionStr",
       "title": "Project due string",
-      "description": "@string indicating date a project/area is due to be finished (default: @due)",
+      "description": "@string indicating date a project/area is due to be finished (default: '@due')",
       "type": "string",
       "default": "@due",
       "required": true
@@ -322,7 +322,7 @@
     {
       "key": "reviewIntervalMentionStr",
       "title": "Project review interval string",
-      "description": "@string indicating review interval for project/area (default: @review)",
+      "description": "@string indicating review interval for project/area (default: '@review')",
       "type": "string",
       "default": "@review",
       "required": true
@@ -330,9 +330,17 @@
     {
       "key": "reviewedMentionStr",
       "title": "Project reviewed string",
-      "description": "@string indicating date a project/area was last reviewed (default: @reviewed)",
+      "description": "@string indicating date a project/area was last reviewed (default: '@reviewed')",
       "type": "string",
       "default": "@reviewed",
+      "required": true
+    },
+    {
+      "key": "nextReviewMentionStr",
+      "title": "Project next review string",
+      "description": "@string indicating date you next want a project/area to be reviewed (default: '@nextReview')",
+      "type": "string",
+      "default": "@nextReview",
       "required": true
     },
     {


### PR DESCRIPTION
@jgclark Sorry I wasn't complete enough in my last post. Here's some more detail:
Scanning my Project Notes with the latest release takes 3.6s and finds only 10 notes

Here's my analysis:

If you are searching for multiple hashtags, *each hashtag* takes 58ms multiplied times the number of hashtags and folders you search in (e.g. in my case 200ms for each folder) .
For example:
```
findNotesMatchingHashtag(#bevProject, Programming/Projects): 0m0s.58ms
findNotesMatchingHashtag(#project, Programming/Projects): 0m0s.53ms
findNotesMatchingHashtag(#homeProject, Programming/Projects): 0m0s.54ms
findNotesMatchingHashtag(#personalProject, Programming/Projects): 0m0s.52ms
```
That really adds up!

...but I found that nearly *all* of that time comes from this one line:

```js
      projectNotesInFolder = DataStore.projectNotes.slice().filter((n) => getFolderFromFilename(n.filename) === folder)
```

So, filtering the projectNotes is expensive.
I made one small change and that was to filter projectNotes once and then pass that to the function.

```js
    const filteredDataStore = DataStore.projectNotes.filter((f) => filteredFolderListWithoutSubdirs.some((s) => f.filename.startsWith(s)))
    ...
    const projectNotesArr = findNotesMatchingHashtag(tag, folder, false, '', true, filteredDataStore)

```

I can do that filter once in 111ms, rather than paying 53ms for every call

This resulted in a 10x speed increase
After the change, the scan takes 0.33 seconds (instead of the 3.6s before)

With another optimization to the DataStore filtering, I was able to get it to 272ms. I might be able to do even better, but given that it's 1/4 a second, I think I'll stop here. :)

Please try this PR out against your notes and compare it to your current/expected results. It *should* be identical just way faster (it is for me). But pls test to be sure!
