### PR TITLE
new command: /Remove >today tags from completed todos

### DIFF
--- a/np.Tidy/CHANGELOG.md
+++ b/np.Tidy/CHANGELOG.md
@@ -1,6 +1,9 @@
 # 🧹 Tidy Up Changelog
 See Plugin [README](https://github.com/NotePlan/plugins/blob/main/np.Tidy/README.md) for full details on the available commands and use from callbacks and templates.
 
+## [0.7.0] - 2023-06-26 @dwertheimer
+- new command: /Remove >today tags from completed todos
+
 ## [0.6.0] - 2023-06-24
 - new **/List conflicted notes** command that creates a new NP note that lists all your notes on your current device with file-level conflicts, along with summary details about them
 - new **/Remove blank notes** command will delete any completely blank notes, or just with a starting '#' character

--- a/np.Tidy/README.md
+++ b/np.Tidy/README.md
@@ -13,6 +13,7 @@ This plugin provides commands to help tidy up your notes:
 - **/Remove time parts from @done() dates** (alias "rtp"): Remove time parts of @done(date time) from recently-updated notes. Can be used with parameters from Template or Callback.
 - **/Remove @done() markers** (alias "rdm"): Remove @done(...) markers from recently-updated notes, optionally just from completed checklist items.
 - **/Remove triggers from recent calendar notes** (alias "rtcn"): Remove one or more triggers from recent (but past) calendar notes.
+- **/Remove >today tags from completed todos** (alias "removeToday" or "rmt"): Removes the ">today" tag still attached to completed/cancelled tasks that keeps them showing up in Today's references (every day forever). Does not touch open tasks.
 
 Most can be used with parameters from a Template, or via an x-callback call.
 
@@ -61,6 +62,7 @@ The available parameters are:
 | Remove section from all notes | keepHeading, runSilently, sectionHeading |
 | Remove section from recent notes | matchType, sectionHeading |
 | Remove time parts from @done() dates | runSilently |
+| Remove >today tags from completed todos | runSilently |
 <!-- | File root-level notes | rootNotesToIgnore | -->
 
 **Tip:** as these are complicated and fiddly to create, **I strongly suggest you use @dwertheimer's excellent [Link Creator plugin]() command "/Get X-Callback-URL"** which makes it vastly easier.

--- a/np.Tidy/plugin.json
+++ b/np.Tidy/plugin.json
@@ -6,8 +6,8 @@
   "plugin.name": "🧹 Tidy Up",
   "plugin.author": "jgclark",
   "plugin.description": "Tidy up and delete various things in your NotePlan notes",
-  "plugin.version": "0.7.0",
-  "plugin.lastUpdateInfo": "v0.7.0: new command: /Remove >today tags from completed todos\nv0.6.0: new commands 'Remove empty notes' 'List conflicted notes' + display improvements.\nv0.5.0: new 'list duplicate notes' command.\n0.4.0: adds command to tidy up triggers in older calendar notes, and way to change settings on iOS.",
+  "plugin.version": "0.7.1",
+  "plugin.lastUpdateInfo": "v0.7.1: new command: /Remove >today tags from completed todos\nv0.6.0: new commands 'Remove empty notes' 'List conflicted notes' + display improvements.\nv0.5.0: new 'list duplicate notes' command.\n0.4.0: adds command to tidy up triggers in older calendar notes, and way to change settings on iOS.",
   "plugin.dependencies": [],
   "plugin.script": "script.js",
   "plugin.url": "https://github.com/NotePlan/plugins/blob/main/np.Tidy/README.md",
@@ -346,6 +346,14 @@
     {
       "title": "Run '/Remove triggers from recent calendar notes?",
       "key": "removeTriggersFromRecentCalendarNotes",
+      "description": "",
+      "type": "bool",
+      "default": false,
+      "required": true
+    }, 
+    {
+      "title": "Run '/Remove >today tags from completed todos?",
+      "key": "removeTodayTagsFromCompletedTodos",
       "description": "",
       "type": "bool",
       "default": false,

--- a/np.Tidy/plugin.json
+++ b/np.Tidy/plugin.json
@@ -6,8 +6,8 @@
   "plugin.name": "🧹 Tidy Up",
   "plugin.author": "jgclark",
   "plugin.description": "Tidy up and delete various things in your NotePlan notes",
-  "plugin.version": "0.6.0",
-  "plugin.lastUpdateInfo": "v0.6.0: new commands 'Remove empty notes' 'List conflicted notes' + display improvements.\nv0.5.0: new 'list duplicate notes' command.\n0.4.0: adds command to tidy up triggers in older calendar notes, and way to change settings on iOS.",
+  "plugin.version": "0.7.0",
+  "plugin.lastUpdateInfo": "v0.7.0: new command: /Remove >today tags from completed todos\nv0.6.0: new commands 'Remove empty notes' 'List conflicted notes' + display improvements.\nv0.5.0: new 'list duplicate notes' command.\n0.4.0: adds command to tidy up triggers in older calendar notes, and way to change settings on iOS.",
   "plugin.dependencies": [],
   "plugin.script": "script.js",
   "plugin.url": "https://github.com/NotePlan/plugins/blob/main/np.Tidy/README.md",
@@ -142,6 +142,15 @@
       ],
       "arguments": [
         "Parameters"
+      ]
+    },
+    {
+      "name": "Remove >today tags from completed todos",
+      "description": "Remove Completed todos that have a >today tag. Can be used with parameters from Template or Callback.",
+      "jsFunction": "removeTodayTagsFromCompletedTodos",
+      "alias": [
+        "removeToday",
+        "rmt"
       ]
     },
     {

--- a/np.Tidy/src/index.js
+++ b/np.Tidy/src/index.js
@@ -13,9 +13,7 @@ import { editSettings } from '@helpers/NPSettings'
 
 const pluginID = 'np.Tidy'
 
-export {
-  fileRootNotes
-} from './fileRoot'
+export { fileRootNotes } from './fileRoot'
 
 export {
   logNotesChangedInInterval,
@@ -26,14 +24,12 @@ export {
   removeTriggersFromRecentCalendarNotes,
   removeDoneTimeParts,
   removeBlankNotes,
-  tidyUpAll
+  tidyUpAll,
+  removeTodayTagsFromCompletedTodos,
 } from './tidyMain'
 
 export { listDuplicates } from './duplicates'
-export {
-  resolveConflictWithCurrentVersion, resolveConflictWithOtherVersion,
-  listConflicts
-} from './conflicts'
+export { resolveConflictWithCurrentVersion, resolveConflictWithOtherVersion, listConflicts } from './conflicts'
 
 /**
  * Other imports/exports

--- a/np.Tidy/src/tidyHelpers.js
+++ b/np.Tidy/src/tidyHelpers.js
@@ -32,6 +32,7 @@ export type TidyConfig = {
   runRemoveDoneTimePartsCommand: boolean,
   runRemoveSectionFromNotesCommand: boolean,
   removeTriggersFromRecentCalendarNotes: boolean,
+  removeTodayTagsFromCompletedTodos: boolean,
   runSilently: boolean,
   _logLevel: string,
 }
@@ -131,7 +132,6 @@ function getLocale(tempConfig: Object): string {
   const envRegion = NotePlan?.environment ? NotePlan?.environment?.regionCode : ''
   const envLanguage = NotePlan?.environment ? NotePlan?.environment?.languageCode : ''
   let tempLocale = castStringFromMixed(tempConfig, 'locale')
-  tempLocale =
-    tempLocale != null && tempLocale !== '' ? tempLocale : envRegion !== '' ? `${envLanguage}-${envRegion}` : 'en-US'
+  tempLocale = tempLocale != null && tempLocale !== '' ? tempLocale : envRegion !== '' ? `${envLanguage}-${envRegion}` : 'en-US'
   return tempLocale
 }

--- a/np.Tidy/src/tidyMain.js
+++ b/np.Tidy/src/tidyMain.js
@@ -42,7 +42,14 @@ export async function tidyUpAll(): Promise<void> {
       await removeOrphanedBlockIDs(config.runSilently)
     }
 
+    if (config.removeTodayTagsFromCompletedTodos) {
+      CommandBar.showLoading(true, `Tidying up completed >today items...`, 0.3)
+      logDebug('tidyUpAll', `Starting Tidying up completed >today items...`)
+      await removeTodayTagsFromCompletedTodos(config.runSilently)
+    }
+
     // Following functions take params; so send runSilently as a param
+
     const param = config.runSilently ? '{"runSilently": true}' : ''
     if (config.runRemoveDoneMarkersCommand) {
       CommandBar.showLoading(true, `Tidying up @done markers...`, 0.4)
@@ -82,12 +89,6 @@ export async function tidyUpAll(): Promise<void> {
       CommandBar.showLoading(true, `Tidying up old triggers ...`, 0.9)
       logDebug('tidyUpAll', `Starting removeDoneTimeParts...`)
       await removeTriggersFromRecentCalendarNotes(param)
-    }
-
-    if (config.removeTodayTagsFromCompletedTodos) {
-      CommandBar.showLoading(true, `Tidying up completed >today items...`, 0.1)
-      logDebug('tidyUpAll', `Starting Tidying up completed >today items...`)
-      await removeTodayTagsFromCompletedTodos(param)
     }
 
     // stop spinner
@@ -767,10 +768,9 @@ export async function removeBlankNotes(runSilently: boolean = false): Promise<vo
  * Plugin entrypoint for command: "/Remove >today tags from completed todos"
  * @author @dwertheimer
  */
-export async function removeTodayTagsFromCompletedTodos(params: string = ''): Promise<void> {
+export async function removeTodayTagsFromCompletedTodos(runSilently: boolean = false): Promise<void> {
   try {
     // Decide whether to run silently
-    const runSilently: boolean = await getTagParamsFromString(params ?? '', 'runSilently', false)
     logDebug(pluginJson, `removeTodayTagsFromCompletedTodos running ${runSilently ? 'silently' : 'with UI messaging enabled'}`)
     const todayNote = DataStore.calendarNoteByDate(new Date())
     const refs = await getTodaysReferences(todayNote).filter((ref) => ref.content.includes('>today'))


### PR DESCRIPTION
I found that I had several completed tasks that had been tagged with ">today" and were still showing up (forever) in my References section. This command gets rid of the ">today" on completed/cancelled tasks and checklists.