### PR TITLE
Paperwork - forgot to bump the version, add to the change log, and handle drawing

### DIFF
--- a/helpers/HTMLView.js
+++ b/helpers/HTMLView.js
@@ -162,7 +162,7 @@ export async function getNoteContentAsHTML(content: string, note: TNote): ?strin
     }
     const converter = new showdown.Converter(converterOptions)
     let body = converter.makeHtml(lines.join(`\n`))
-    body = `<style>img { max-width: 100%; max-height: 100%; }</style>${body}` // fix for bug in showdown
+    body = `<style>img { background: white; max-width: 100%; max-height: 100%; }</style>${body}` // fix for bug in showdown
     
     const imgTagRegex = /<img src=\"(.*?)\"/g
     const matches = [...body.matchAll(imgTagRegex)]
@@ -172,8 +172,10 @@ export async function getNoteContentAsHTML(content: string, note: TNote): ?strin
         const imagePath = match[1]
         try {
             // Handle both absolute and relative paths
-            const fullPath = `../../../Notes/${noteDirPath}/${decodeURI(imagePath)}`
-
+            let fullPath = `../../../Notes/${noteDirPath}/${decodeURI(imagePath)}`
+            if(fullPath.endsWith('.drawing')) {
+              fullPath = fullPath.replace('.drawing', '.png')
+            }
             const data = await DataStore.loadData(fullPath)
             if (data) {
                 const base64Data = `data:image/png;base64,${data.toString('base64')}`

--- a/np.Preview/CHANGELOG.md
+++ b/np.Preview/CHANGELOG.md
@@ -1,6 +1,9 @@
 # What's Changed in 🖥️ Previews plugin?
 See [website README for more details](https://github.com/NotePlan/plugins/tree/main/np.Preview), and how to configure it.
 
+## [0.4.4] - 2025-02-20
+- added embed images to preview, fixed some bugs
+
 ## [0.4.3] - 2023-11-10
 - stops the Preview window stealing focus in live preview mode
 

--- a/np.Preview/README.md
+++ b/np.Preview/README.md
@@ -14,7 +14,6 @@ It adds a 'Print (opens in system browser)' button to the preview window (on mac
 ## Limitations
 This is designed to be a temporary solution while we wait for similar functionality to get baked into the NotePlan app itself. To that end, I don't intend to be making many improvements to this.  In particular I'm aware that:
 
-- it does not render embedded images
 -  there are bugs in the rendering of frontmatter arising from one of the third-party libraries this uses.
 
 ## Automatic updating

--- a/np.Preview/plugin.json
+++ b/np.Preview/plugin.json
@@ -7,8 +7,8 @@
   "plugin.icon": "",
   "plugin.author": "Jonathan Clark",
   "plugin.url": "https://github.com/NotePlan/plugins/tree/main/np.Preview/",
-  "plugin.version": "0.4.3",
-  "plugin.lastUpdateInfo": "v0.4.3: stop updates stealing focus from the note editor.\nv0.4.2: fix regression stopping Mermaid rendering.\nv0.4.1: improve display of [[notelinks]], ==highlights== and ~underlining~.\nv0.4.0: new command \"/start live preview\".\nv0.3.1: display improvements and turn off print button for iOS.\nv0.3.0: print button, trigger, updated Mermaid library, use appropriate Mermaid theme.",
+  "plugin.version": "0.4.4",
+  "plugin.lastUpdateInfo": "v0.4.4: added embed images to preview, fixed some bugs",
   "plugin.changelog": "https://github.com/NotePlan/plugins/blob/main/np.Preview/CHANGELOG.md",
   "plugin.dependencies": [],
   "plugin.requiredFiles": [


### PR DESCRIPTION
Paperwork - forgot to bump the version and add to the change log
Functionality -If an image is a drawing we need to look at the png and give it a white background so it can be read on darkmode.