### PR TITLE
add trigger as well as make silent run more silent'er

### DIFF
--- a/np.Tidy/CHANGELOG.md
+++ b/np.Tidy/CHANGELOG.md
@@ -1,6 +1,9 @@
 # 🧹 Tidy Up Changelog
 See Plugin [README](https://github.com/NotePlan/plugins/blob/main/np.Tidy/README.md) for full details on the available commands and use from callbacks and templates.
 
+## [0.14.8] - 2025-03-18 @cwhittl
+- Adds a trigger capability, so the you can generate repeats for notes within the last 4 days when on a calendar note (probalby not a good thing to use on a regular note, see the repeat extension for that). The trigger line is `triggers: onEditorWillSave => np.Tidy.generateRepeatsFromRecentNotes`.
+
 ## [0.14.7] - 2025-02-18 @jgclark
 - Stop lots of popups appearing when running **/Generate @repeats in recent notes** command (thanks, @kanera).
 - The **/List stubs** command now understands line links (and so ignores the part of the link after the `^` character) (thanks, @ChrisMetcalf).

--- a/np.Tidy/CHANGELOG.md
+++ b/np.Tidy/CHANGELOG.md
@@ -2,7 +2,9 @@
 See Plugin [README](https://github.com/NotePlan/plugins/blob/main/np.Tidy/README.md) for full details on the available commands and use from callbacks and templates.
 
 ## [0.14.8] - 2025-03-18 @cwhittl
-- Adds a trigger capability, so the you can generate repeats for notes within the last 4 days when on a calendar note (probalby not a good thing to use on a regular note, see the repeat extension for that). The trigger line is `triggers: onEditorWillSave => np.Tidy.generateRepeatsFromRecentNotes`.
+- Introduces a trigger capability that allows generating repeats for notes from the past four days when working within a calendar note. This feature is not recommended for regular notes, refer to the repeat extension for that use case. 
+The trigger line is:
+`triggers: onEditorWillSave => np.Tidy.generateRepeatsFromRecentNotes.`
 
 ## [0.14.7] - 2025-02-18 @jgclark
 - Stop lots of popups appearing when running **/Generate @repeats in recent notes** command (thanks, @kanera).

--- a/np.Tidy/plugin.json
+++ b/np.Tidy/plugin.json
@@ -6,8 +6,8 @@
   "plugin.name": "🧹 Tidy Up",
   "plugin.author": "jgclark",
   "plugin.description": "Tidy up and delete various things in your NotePlan notes",
-  "plugin.version": "0.14.7",
-  "plugin.lastUpdateInfo": "v0.14.7: fix regression in '/generate @repeats from recent notes' command.\nv0.14.6: fix to allow top-level tasks to be run by xcallback.\nv0.14.5: fix to allow top-level tasks to be run by xcallback.\nv0.14.4: fix to allow blank Calendar notes to be removed by '/remove blank notes'.\nv0.14.3: fix unwanted popups in '/generate @repeats from recent notes' command.\nv0.14.2: add new option to file root notes.\nv0.14.1: rebuild.\nv0.14.0: new '/Generate repeats' command.\nv0.13.0: '/List conflicted notes' now clears out all copies, and offers side-by-side viewing of conflicted note versions. Also bug fixes.\nv0.12.1: '/List conflicted notes' now covers Calendar notes as well.\nv0.12.0: add more capability to '/List conflicted notes'.\nv0.11.0: new command '/find doubled notes'.\nv0.10.0: fix bug in moving top level tasks, and adds support for indented tasks.",
+  "plugin.version": "0.14.8",
+  "plugin.lastUpdateInfo": "v0.14.8: add onEditorWillSave for use in calendar templates to use with referenced repeats.\nv0.14.7: fix regression in '/generate @repeats from recent notes' command.\nv0.14.6: fix to allow top-level tasks to be run by xcallback.\nv0.14.5: fix to allow top-level tasks to be run by xcallback.\nv0.14.4: fix to allow blank Calendar notes to be removed by '/remove blank notes'.\nv0.14.3: fix unwanted popups in '/generate @repeats from recent notes' command.\nv0.14.2: add new option to file root notes.\nv0.14.1: rebuild.\nv0.14.0: new '/Generate repeats' command.\nv0.13.0: '/List conflicted notes' now clears out all copies, and offers side-by-side viewing of conflicted note versions. Also bug fixes.\nv0.12.1: '/List conflicted notes' now covers Calendar notes as well.\nv0.12.0: add more capability to '/List conflicted notes'.\nv0.11.0: new command '/find doubled notes'.\nv0.10.0: fix bug in moving top level tasks, and adds support for indented tasks.",
   "plugin.dependencies": [],
   "plugin.script": "script.js",
   "plugin.url": "https://github.com/NotePlan/plugins/blob/main/np.Tidy/README.md",
@@ -227,6 +227,15 @@
       ],
       "arguments": [
         "Parameters"
+      ]
+    },
+    {
+      "hidden": true,
+      "name": "generateRepeatsFromRecentNotes",
+      "description": "onEditorWillSave",
+      "jsFunction": "silentlyGenerateRepeatsFromRecentNotes",
+      "triggersHandled": [
+        "onEditorWillSave"
       ]
     },
     {

--- a/np.Tidy/src/index.js
+++ b/np.Tidy/src/index.js
@@ -32,12 +32,11 @@ export { generateRepeatsFromRecentNotes } from './repeats'
 export { listStubs } from './stubs'
 export { moveTopLevelTasksInEditor } from './topLevelTasks'
 export { listPotentialDoubles } from './doubledNotes'
-
 /**
  * Other imports/exports
  */
 // eslint-disable-next-line import/order
-export { onUpdateOrInstall, init, onSettingsUpdated } from './triggers-hooks'
+export { onUpdateOrInstall, init, onSettingsUpdated, silentlyGenerateRepeatsFromRecentNotes } from './triggers-hooks'
 
 // Note: not yet written or used:
 // export { onOpen, onEditorWillSave } from './NPTriggers-Hooks'

--- a/np.Tidy/src/repeats.js
+++ b/np.Tidy/src/repeats.js
@@ -58,9 +58,10 @@ export async function generateRepeatsFromRecentNotes(params: string = ''): Promi
     const jsDateToStartLooking = momentToStartLooking.toDate()
 
     const startTime = new Date() // for timing only
-    CommandBar.showLoading(true, `Finding completed @repeats`)
-    await CommandBar.onAsyncThread()
-
+    if (!runSilently) {
+      CommandBar.showLoading(true, `Finding completed @repeats`)
+    }
+    CommandBar.onAsyncThread()
     // Find past calendar notes changed in the last numDays (or all if numDays === 0)
     // v2 method:
     const recentNotes = config.numDays > 0 ? getNotesChangedInInterval(config.numDays, ['Notes', 'Calendar']) : getAllNotesOfType(['Notes', 'Calendar'])
@@ -73,11 +74,11 @@ export async function generateRepeatsFromRecentNotes(params: string = ''): Promi
       const num = await generateRepeats(true, thisNote)
       numGenerated += num
     }
+    
     await CommandBar.onMainThread()
-    CommandBar.showLoading(false)
-
     logInfo('generateRepeatsFromRecentNotes', `Generated ${String(numGenerated)} new @repeat(...)s from ${String(recentNotes.length)} recent notes, in ${timer(startTime)}`)
     if (!runSilently) {
+      CommandBar.showLoading(false)
       await showMessage(`Generated ${String(numGenerated)} new @repeats from ${String(recentNotes.length)} recent notes`, 'OK', 'Tidy: Generate Repeats')
     }
     return

--- a/np.Tidy/src/triggers-hooks.js
+++ b/np.Tidy/src/triggers-hooks.js
@@ -4,6 +4,7 @@
 import pluginJson from '../plugin.json' // gives you access to the contents of plugin.json
 import { logError, logDebug, logInfo, logWarn, timer, clo } from '@helpers/dev'
 import { updateSettingData, pluginUpdated } from '@helpers/NPConfiguration'
+import { generateRepeatsFromRecentNotes } from "./repeats"
 
 const pluginID = 'np.Tidy'
 
@@ -109,3 +110,21 @@ export async function onSettingsUpdated(): Promise<void> {
   // Placeholder only to stop error in logs
   logDebug(pluginJson, `${pluginJson['plugin.id']} :: onSettingsUpdated running`)
 }
+
+
+/**
+ * onEditorWillSave
+ * Respond to onEditorWillSave trigger for the currently open note. 
+ * Will fire generateRepeatsFromRecentNotes() silently for the last 4 days.
+ */
+export async function silentlyGenerateRepeatsFromRecentNotes(): Promise<void> {
+  try {
+    if (Editor.content && Editor.note) {
+      await generateRepeatsFromRecentNotes('{"numDays":4, "runSilently": true}')
+    } else {
+      throw new Error("Cannot get Editor details. Is there a note open in the Editor?")
+    }
+  } catch (error) {
+    logError(pluginJson, error.message)
+  }
+} 


### PR DESCRIPTION
Introduces a trigger capability that allows generating repeats for notes from the past four days when working within a calendar note. This feature is not recommended for regular notes, refer to the repeat extension for that use case. 
The trigger line is:
`triggers: onEditorWillSave => np.Tidy.generateRepeatsFromRecentNotes.`