### PR TITLE
Noteplan flow context comment updates

### DIFF
--- a/flow-typed/Noteplan.js
+++ b/flow-typed/Noteplan.js
@@ -1800,6 +1800,7 @@ declare class Clipboard {
   // Impossible constructor
   constructor(_: empty): empty;
   /**
+   * Clipboard.string
    * Get or set the current text of the clipboard.
    */
   static string: string;
@@ -2054,6 +2055,7 @@ declare interface CoreNoteFields {
    */
   rename(newFilename: string): string;
   /**
+   * [Editor|Note].insertTextInCharacterIndex()
    * Inserts the given text at the given character position (index)
    * Note: this is not quite the same as Editor.insertTextAtCharacterIndex()
    * @param text 	  - Text to insert
@@ -2061,6 +2063,7 @@ declare interface CoreNoteFields {
    */
   insertTextInCharacterIndex(text: string, index: number): void;
   /**
+   * [Editor|Note].replaceTextAtCharacterRange()
    * Replaces the text at the given range with the given text
    * Note: this is not quite the same name as Editor.replaceTextInCharacterRange()
    * @param text 	    - Text to insert
@@ -2069,80 +2072,94 @@ declare interface CoreNoteFields {
    */
   replaceTextAtCharacterRange(text: string, location: number, length: number): void;
   /**
+   * [Editor|Note].paragraphRangeAtCharacterIndex()
    * Returns a range object of the full paragraph of the given character
    * position.
    */
   paragraphRangeAtCharacterIndex(characterPosition: number): TRange;
 
   /**
+   * [Editor|Note].insertParagraph()
    * Inserts a plain paragraph at the given line index.
    * WARNING: 'lineIndex' can be different in `Editor` and `Note` contexts, even for the same paragraph, because frontmatter lines are not included in the `Editor` context since ~v3.16.3.
    */
   insertParagraph(name: string, lineIndex: number, type: ParagraphType): void;
 
   /**
+   * [Editor|Note].insertTodo()
    * Inserts a todo at the given line index
    * WARNING: 'lineIndex' can be different in `Editor` and `Note` contexts, even for the same paragraph, because frontmatter lines are not included in the `Editor` context since ~v3.16.3.
    */
   insertTodo(name: string, lineIndex: number): void;
 
   /**
+   * [Editor|Note].insertCompletedTodo()
    * Inserts a completed todo at the given line index
    * WARNING: 'lineIndex' can be different in `Editor` and `Note` contexts, even for the same paragraph, because frontmatter lines are not included in the `Editor` context since ~v3.16.3.
    */
   insertCompletedTodo(name: string, lineIndex: number): void;
 
   /**
+   * [Editor|Note].insertCancelledTodo()
    * Inserts a cancelled todo at the given line index
    * WARNING: 'lineIndex' can be different in `Editor` and `Note` contexts, even for the same paragraph, because frontmatter lines are not included in the `Editor` context since ~v3.16.3.
    */
   insertCancelledTodo(name: string, lineIndex: number): void;
 
   /**
+   * [Editor|Note].insertScheduledTodo()
    * Inserts a scheduled todo at the given line index
    * WARNING: 'lineIndex' can be different in `Editor` and `Note` contexts, even for the same paragraph, because frontmatter lines are not included in the `Editor` context since ~v3.16.3.
    */
   insertScheduledTodo(name: string, lineIndex: number, date: Date): void;
 
   /**
+   * [Editor|Note].insertQuote()
    * Inserts a quote at the given line index
    * WARNING: 'lineIndex' can be different in `Editor` and `Note` contexts, even for the same paragraph, because frontmatter lines are not included in the `Editor` context since ~v3.16.3.
    */
   insertQuote(name: string, lineIndex: number): void;
 
   /**
+   * [Editor|Note].insertList()
    * Inserts a list (bullet) item at the given line index
    * WARNING: 'lineIndex' can be different in `Editor` and `Note` contexts, even for the same paragraph, because frontmatter lines are not included in the `Editor` context since ~v3.16.3.
    */
   insertList(name: string, lineIndex: number): void;
 
   /**
+   * [Editor|Note].insertHeading()
    * Inserts a heading at the given line index
    * WARNING: 'lineIndex' can be different in `Editor` and `Note` contexts, even for the same paragraph, because frontmatter lines are not included in the `Editor` context since ~v3.16.3.
    */
   insertHeading(name: string, lineIndex: number, level: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8): void;
 
   /**
+   * [Editor|Note].appendTodo()
    * Appends a todo at the end of the note
    */
   appendTodo(content: string): void;
 
   /**
+   * [Editor|Note].prependTodo()
    * Prepends a todo at the beginning of the note (after the title heading)
    */
   prependTodo(content: string): void;
 
   /**
+   * [Editor|Note].appendParagraph()
    * Appends a paragraph at the end of the note
    */
   appendParagraph(content: string, type: ParagraphType): void;
 
   /**
+   * [Editor|Note].prependParagraph()
    * Prepends a paragraph at the beginning of the note (after the title heading)
    */
   prependParagraph(content: string, type: ParagraphType): void;
 
   /**
+   * [Editor|Note].addTodoBelowHeadingTitle()
    * Inserts a todo below the given title of a heading (at the beginning or end of existing text)
    * @param {string} content - Text of the todo
    * @param {string} headingTitle - Title of the heading (without '#  Markdown)
@@ -2152,6 +2169,7 @@ declare interface CoreNoteFields {
   addTodoBelowHeadingTitle(content: string, headingTitle: string, shouldAppend: boolean, shouldCreate: boolean): void;
 
   /**
+   * [Editor|Note].addParagraphBelowHeadingTitle()
    * Inserts a paragraph below the given title of a heading (at the beginning or end of existing text)
    * @param {string} content - Text of the paragraph
    * @param {ParagraphType} paragraphType
@@ -2162,6 +2180,7 @@ declare interface CoreNoteFields {
   addParagraphBelowHeadingTitle(content: string, paragraphType: ParagraphType, headingTitle: string, shouldAppend: boolean, shouldCreate: boolean): void;
 
   /**
+   * [Editor|Note].appendTodoBelowHeadingLineIndex()
    * Appends a todo below the given heading index (at the end of existing text)
    * @param {string} content - Text of the todo
    * @param {number} headingLineIndex - Line index of the heading (get the line index from a paragraph object). WARNING: 'lineIndex' can be different in `Editor` and `Note` contexts, even for the same paragraph, because frontmatter lines are not included in the `Editor` context since ~v3.16.3.
@@ -2481,6 +2500,7 @@ declare class HTMLView {
    */
   +id: string;
   /**
+   * HTMLView.customId
    * Set / get a custom identifier, so you don't need to cache the unique id.
    * Example: NotePlan.editors[0].customId = "test"
    * Generally speaking you should start this string with the plugin's ID, e.g. pluginJson['plugin.id'], and append '.name' if you need to have more than 1 HTML window type in the same plugin.
@@ -2489,6 +2509,7 @@ declare class HTMLView {
    */
   customId: string;
   /**
+   * HTMLView.type
    * Get type of window where the window is embedded in.
    * Possible values: main|split|floating|unsupported
    * It's unsupported on iOS at the moment.
@@ -2497,11 +2518,13 @@ declare class HTMLView {
    */
   +type: string;
   /**
+   * HTMLView.focus()
    * Send the window to the front.
    * Note: Available from NotePlan v3.8.1 build 973
    */
   focus(): void;
   /**
+   * HTMLView.close()
    * Close the HTML window.
    * Note: Available from NotePlan v3.8.1 build 973
    */
@@ -2517,6 +2540,7 @@ declare class HTMLView {
    */
   static runJavaScript(code: string, windowId: string | void): Promise<void>;
   /**
+   * HTMLView.windowRect
    * Set / get the position and size of an HTMLView window. Returns an object with x, y, width, height values.
    * If you want to change the coordinates or size, save the rect in a variable, modify the variable, then assign it to windowRect.
    * The position of the window might not be very intuitive, because the coordinate system of the screen works differently (starts at the bottom left for example). Recommended is to adjust the size and position of the window relatively to it's values or other windows.

--- a/flow-typed/Noteplan.js
+++ b/flow-typed/Noteplan.js
@@ -42,22 +42,26 @@ declare var Editor: TEditor
  */
 declare interface TEditor extends CoreNoteFields {
   /**
+   * Editor.note
    * Get the note object of the opened note in the editor.
    * WARNING: from @jgclark: since about v3.16.3, Editor operates differently from Note when a note has frontmatter: for the Editor does NOT include frontmatter lines, and they are NOT selectable.
    */
   +note: ?TNote;
   /**
+   * Editor.insertTextAtCharacterIndex()
    * Inserts the given text at the given character position (index)
    * @param text 	  - Text to insert
    * @param index   - Position to insert at (you can get this using 'renderedSelection' for example)
    */
   insertTextAtCharacterIndex(text: string, index: number): void;
   /**
+   * Editor.selectedLinesText
    * Get an array of selected lines. The cursor doesn't have to select the full
    * line, NotePlan returns all complete lines the cursor "touches".
    */
   +selectedLinesText: $ReadOnlyArray<string>;
   /**
+   * Editor.selectedParagraphs
    * Get an array of selected paragraphs. The cursor doesn't have to select the
    * full paragraph, NotePlan returns all complete paragraphs the cursor "touches".
    * Note: not all of the paragraph object data is complete, e.g. "headingLevel", "heading" and other properties may not be set properly.
@@ -67,25 +71,30 @@ declare interface TEditor extends CoreNoteFields {
    */
   +selectedParagraphs: $ReadOnlyArray<TParagraph>;
   /**
+   * Editor.selection
    * Get the raw selection range (hidden Markdown is considered).
    * Note: frontmatter is not included in the character counts, since ~v3.16.3
    */
   +selection: ?TRange;
   /**
+   * Editor.renderedSelection
    * Get the rendered selection range (hidden Markdown is NOT considered).
    */
   +renderedSelection: ?TRange;
   /**
+   * Editor.selectedText
    * Get the selected text.
    */
   +selectedText: ?string;
 
   /**
+   * Editor.insertTextAtCursor()
    * Inserts the given text at the current cursor position
    * @param text - Text to insert
    */
   insertTextAtCursor(text: string): void;
   /**
+   * Editor.insertParagraphAtCursor()
    * Inserts a plain paragraph before the selected paragraph (or the paragraph the cursor is currently positioned)
    * @param name - Text of the paragraph
    * @param type - paragraph type
@@ -93,11 +102,13 @@ declare interface TEditor extends CoreNoteFields {
    */
   insertParagraphAtCursor(name: string, type: ParagraphType, indents: number): void;
   /**
+   * Editor.replaceSelectionWithText()
    * Replaces the current cursor selection with the given text
    * @param text - Text to insert
    */
   replaceSelectionWithText(text: string): void;
   /**
+   * Editor.openNoteByFilename()
    * Opens a note using the given filename. Returns the note if it exists or fails, returning null if the file has not been created yet.
    * @param {string} filename - Filename of the note file (can be without extension), but has to include the relative folder such as `folder/filename.txt`. If the note doesn't exist, then returns null
    * @param {boolean?} newWindow - (optional) Open note in new window (default = false)?
@@ -122,6 +133,7 @@ declare interface TEditor extends CoreNoteFields {
     stayInSpace?: boolean,
   ): Promise<TNote | void>;
   /**
+   * Editor.openNoteByTitle()
    * Opens a note by searching for the give title (first line of the note)
    * Note: 'splitView' parameter available for macOS from v3.4
    * @param {string} title - Title (case sensitive) of the note (first line)
@@ -133,6 +145,7 @@ declare interface TEditor extends CoreNoteFields {
    */
   openNoteByTitle(title: string, newWindow?: boolean, highlightStart?: number, highlightEnd?: number, splitView?: boolean): Promise<TNote | void>;
   /**
+   * Editor.openNoteByTitleCaseInsensitive()
    * Opens a note by searching for the give title (first line of the note)
    * Note: 'splitView' parameter available for macOS from v3.4
    * @param {string} title - Title (case sensitive) of the note (first line)
@@ -151,6 +164,7 @@ declare interface TEditor extends CoreNoteFields {
     splitView?: boolean,
   ): Promise<TNote | void>;
   /**
+   * Editor.openNoteByDate()
    * Opens a calendar note by the given date
    * Note: 'splitView' parameter available for macOS from v3.4
    * Note: 'timeframe' parameter available from v3.6
@@ -166,6 +180,7 @@ declare interface TEditor extends CoreNoteFields {
    */
   openNoteByDate(date: Date, newWindow?: boolean, highlightStart?: number, highlightEnd?: number, splitView?: boolean, timeframe?: string, parent?: string): Promise<TNote | void>;
   /**
+   * Editor.openNoteByDateString()
    * Opens a calendar note by the given date string.
    * @param {string} dateString - The date string that should be opened, in ISO format ("YYYY-MM-DD") or filename format for days ("YYYYMMDD") or (from v3.6) in "YYYY-Wnn" format for weeks
    * @param {boolean} newWindow - (optional) Open note in new window (default = false)?
@@ -179,6 +194,7 @@ declare interface TEditor extends CoreNoteFields {
    */
   openNoteByDateString(dateString: string, newWindow?: boolean, highlightStart?: number, highlightEnd?: number, splitView?: boolean): Promise<TNote | void>;
   /**
+   * Editor.openWeeklyNote()
    * Opens a weekly calendar note by the given year and week number
    * Note: available from v3.6
    * @param {number} year           - The year of the week
@@ -191,12 +207,14 @@ declare interface TEditor extends CoreNoteFields {
    */
   openWeeklyNote(year: number, weeknumber: number, newWindow?: boolean, highlightStart?: number, highlightEnd?: number, splitView?: boolean): Promise<TNote | void>;
   /**
+   * Editor.selectAll()
    * Selects the full text in the Editor.
    * Note: Available from v3.2
    * Note: From ~v3.16.3, this does not include the frontmatter lines.
    */
   selectAll(): void;
   /**
+   * Editor.select()
    * (Raw) select text in the editor (like select 10 characters = length from position 2 = start)
    * Raw means here that the position is calculated with the Markdown revealed, including Markdown links and folded text.
    * Note: From ~v3.16.3, this does not include the frontmatter lines.
@@ -205,6 +223,7 @@ declare interface TEditor extends CoreNoteFields {
    */
   select(start: number, length: number): void;
   /**
+   * Editor.renderedSelect()
    * (Rendered) select text in the editor (like select 10 characters = length from position 2 = start)
    * Rendered means here that the position is calculated with the Markdown hidden, including Markdown links and folded text.
    * Note: From ~v3.16.3, this does not include the frontmatter lines.
@@ -213,18 +232,21 @@ declare interface TEditor extends CoreNoteFields {
    */
   renderedSelect(start: number, length: number): void;
   /**
+   * Editor.copySelection()
    * Copies the currently selected text in the editor to the system clipboard.
    * See also Clipboard object.
    * Note: Available from v3.2
    */
   copySelection(): void;
   /**
+   * Editor.pasteClipboard()
    * Pastes the current content in the system clipboard into the current selection in the editor.
    * See also Clipboard object.
    * Note: Available from v3.2
    */
   pasteClipboard(): void;
   /**
+   * Editor.highlight()
    * Scrolls to and highlights the given paragraph.
    * If the paragraph is folded, it will be unfolded.
    * Note: From ~v3.16.3, this does not include the frontmatter lines.
@@ -232,6 +254,7 @@ declare interface TEditor extends CoreNoteFields {
    */
   highlight(paragraph: TParagraph): void;
   /**
+   * Editor.highlightByRange()
    * Scrolls to and highlights the given character range.
    * If the range exists in a folded heading, it will be unfolded.
    * Note: From ~v3.16.3, this does not include the frontmatter lines.
@@ -239,6 +262,7 @@ declare interface TEditor extends CoreNoteFields {
    */
   highlightByRange(range: TRange): void;
   /**
+   * Editor.highlightByIndex()
    * Scrolls to and highlights the given range defined by the character index and the character length it should cover.
    * If the paragraph is folded, it will be unfolded.
    * Note: Available from v3.0.23
@@ -248,12 +272,14 @@ declare interface TEditor extends CoreNoteFields {
    */
   highlightByIndex(index: number, length: number): void;
   /**
+   * Editor.toggleFolding()
    * Folds the given paragraph or unfolds it if its already folded. If the paragraph is not a heading, it will look for the heading this paragraph exists under.
    * Note: Available from v3.6.0
    * @param {TParagraph}
    */
   toggleFolding(paragraph: TParagraph): void;
   /**
+   * Editor.isFolded()
    * Checks if the given paragraph is folded or not. If it's not a heading, it will look for the heading this paragraph exists under.
    * Note: Available from v3.6.0
    * @param {TParagraph}
@@ -261,6 +287,7 @@ declare interface TEditor extends CoreNoteFields {
    */
   isFolded(paragraph: TParagraph): boolean;
   /**
+   * Editor.showLoading()
    * Shows or hides a window with a loading indicator or a progress ring (if progress is defined) and an info text (optional).
    * `text` is optional, if you define it, it will be shown below the loading indicator.
    * `progress` is also optional. If it's defined, the loading indicator will change into a progress ring. Use float numbers from 0-1 to define how much the ring is filled.
@@ -272,6 +299,7 @@ declare interface TEditor extends CoreNoteFields {
    */
   showLoading(visible: boolean, text?: ?string, progress?: number): void;
   /**
+   * Editor.onAsyncThread()
    * If you call this, anything after `await CommandBar.onAsyncThread()` will run on an asynchronous thread.
    * Use this together with `showLoading`, so that the work you do is not blocking the user interface.
    * Otherwise the loading window will be also blocked.
@@ -284,6 +312,7 @@ declare interface TEditor extends CoreNoteFields {
    */
   onAsyncThread(): Promise<void>;
   /**
+   * Editor.onMainThread()
    * If you call this, anything after `await CommandBar.onMainThread()` will run on the main thread.
    * Call this after `onAsyncThread`, once your background work is done.
    * It is safe to call Editor and other user interface functions on the main thread.
@@ -292,6 +321,7 @@ declare interface TEditor extends CoreNoteFields {
    */
   onMainThread(): Promise<void>;
   /**
+   * Editor.save()
    * Save content of Editor to file. This can be used before updateCache() to ensure latest changes are available quickly.
    * Warning: beware possiblity of this causing an infinite loop, particularly if used in a function call be an onEditorWillSave trigger.
    * WARNING: from @jgclark and @dwertheimer: use helper editor.js function saveEditorIfNecessary() instead, as too often this silently fails, and stops plugins from running.
@@ -299,6 +329,7 @@ declare interface TEditor extends CoreNoteFields {
    */
   save(): Promise<void>;
   /**
+   * Editor.availableThemes
    * Get the names of all supported themes (including custom themes imported into the Theme folder).
    * Use together with `.setTheme(name)`
    * Note: available from v3.6.2, returning array of these objects:
@@ -313,6 +344,7 @@ declare interface TEditor extends CoreNoteFields {
    */
   +availableThemes: $ReadOnlyArray<Object>;
   /**
+   * Editor.currentTheme
    * Get the current theme name and mode as an object with these keys:
    *  - "name" in the JSON theme
    *  - "filename" of the JSON theme file
@@ -323,6 +355,7 @@ declare interface TEditor extends CoreNoteFields {
    */
   +currentTheme: Object;
   /**
+   * Editor.setTheme()
    * Change the current theme.
    * Get all available theme names using `.availableThemes`. Custom themes are also supported.
    * Note: Available from NotePlan v3.1
@@ -330,12 +363,14 @@ declare interface TEditor extends CoreNoteFields {
    */
   setTheme(name: string): void;
   /**
+   * Editor.saveDefaultTheme()
    * Save theme as the default for the specified mode.
    * @param {string} theme_name (already-installed; not filename)
    * @param {string} mode "dark" | "light" | "auto"
    */
   saveDefaultTheme(name: string, mode: string): void;
   /**
+   * Editor.addTheme()
    * Add a new theme using the raw json string. It will be added as a custom theme and you can load it right away with `.setTheme(name)` using the filename defined as second parameter. Use ".json" as file extension.
    * It returns true if adding was successful and false if not. An error will be also printed into the console.
    * Adding a theme might fail, if the given json text was invalid.
@@ -346,6 +381,7 @@ declare interface TEditor extends CoreNoteFields {
    */
   addTheme(json: string, filename: string): boolean;
   /**
+   * Editor.currentSystemMode
    * Get the current system mode, either "dark" or "light.
    * Note: Available from NotePlan v3.6.2+
    * @returns {string}
@@ -353,12 +389,14 @@ declare interface TEditor extends CoreNoteFields {
   +currentSystemMode: string;
 
   /**
+   * Editor.id
    * Get a unique ID for the editor to make it easier to identify it later
    * Note: Available from NotePlan v3.8.1 build 973
    * @returns {string}
    */
   +id: string;
   /**
+   * Editor.customId
    * Set / get a custom identifier, so you don't need to cache the unique id.
    * Generally speaking you should set (or at least start) this string with the plugin's ID, e.g. pluginJson['plugin.id']
    * Note: Available from NotePlan v3.8.1 build 973
@@ -366,6 +404,7 @@ declare interface TEditor extends CoreNoteFields {
    */
   customId: string;
   /**
+   * Editor.windowType
    * Get the type of window where the editor is embedded in.
    * Possible values: main|split|floating|unsupported
    * It's unsupported on iOS at the moment.
@@ -374,16 +413,19 @@ declare interface TEditor extends CoreNoteFields {
    */
   +windowType: string;
   /**
+   * Editor.focus()
    * Get the cursor into a specific editor and send the window to the front.
    * Note: Available from NotePlan v3.8.1 build 973
    */
   focus(): void;
   /**
+   * Editor.close()
    * Close the split view or window. If it's the main note, it will close the complete main window.
    * Note: Available from NotePlan v3.8.1 build 973
    */
   close(): void;
   /**
+   * Editor.windowRect
    * Set / get the position and size of the window that contains the editor. Returns an object with x, y, width, height values.
    * If you want to change the coordinates or size, save the rect in a variable, modify the variable, then assign it to windowRect.
    * The position of the window might not be very intuitive, because the coordinate system of the screen works differently (starts at the bottom left for example). Recommended is to adjust the size and position of the window relatively to it's values or other windows.
@@ -399,12 +441,14 @@ declare interface TEditor extends CoreNoteFields {
    */
   windowRect: Rect;
   /**
+   * Editor.skipNextRepeatDeletionCheck
    * Prevents the next "Delete future todos" dialog when deleting a line with a @repeat(...) tag. Will be reset automatically.
    * Note: introduced in 3.15 build 1284/1230
    * @param {boolean}
    */
   skipNextRepeatDeletionCheck: boolean;
   /**
+   * Editor.setFrontmatterAttribute()
    * Sets a frontmatter attribute with the given key and value.
    * If the key already exists, updates its value. If it doesn't exist, adds a new key-value pair.
    * To set multiple frontmatter attributes, use frontmatterAttributes = key-value object.
@@ -424,11 +468,13 @@ declare class DataStore {
   // Impossible constructor
   constructor(_: empty): empty;
   /**
+   * DataStore.defaultFileExtension
    * Get the preference for the default file (note) extension,
    * such as "txt" or "md".
    */
   static +defaultFileExtension: string;
   /**
+   * DataStore.folders
    * Get all folders as array of strings.
    * Note: Includes the root "/" and folders that begin with "@" such as "@Archive" and "@Templates". It excludes the trash folder though.
    * Note: from v3.18.0 v1417, this includes Teamspace root folders.
@@ -445,12 +491,14 @@ declare class DataStore {
    */
   static createFolder(folderPath: string): boolean;
   /**
+   * DataStore.calendarNotes
    * Get all calendar notes.
    * Note: from v3.4 this includes all future-referenced dates, not just those with an actual created note.
    * Note: from v3.17.0, this includes Teamspace calendar notes (with the teamspace ID in the filename).
    */
   static +calendarNotes: $ReadOnlyArray<TNote>;
   /**
+   * DataStore.projectNotes
    * Get all regular notes (earlier called "project notes").
    * From v3.17.0, this includes Teamspace regular notes. These have as their 'filename' a path represented with an ID, followed by any number of folders, and then a note ID.
    * Example: %%NotePlanCloud%%/275ce631-6c20-4f76-b5fd-a082a9ac5160/Projects/Research/b79735c9-144b-4fbf-8633-eaeb40c182fa
@@ -459,6 +507,7 @@ declare class DataStore {
    */
   static +projectNotes: $ReadOnlyArray<TNote>;
   /**
+   * DataStore.hashtags
    * Get all cached hashtags (#tag) that are used across notes.
    * It returns hashtags without leading '#'.
    * @type {Array<string>}
@@ -466,6 +515,7 @@ declare class DataStore {
    */
   static +hashtags: $ReadOnlyArray<string>;
   /**
+   * DataStore.mentions
    * Get all cached mentions (@name) that are used across notes.
    * It returns mentions without leading '@'.
    * Note: Available from v3.6.0
@@ -473,18 +523,21 @@ declare class DataStore {
    */
   static +mentions: $ReadOnlyArray<string>;
   /**
+   * DataStore.filters
    * Get list of all filter names
    * Note: Available from v3.6.0
    * @type {Array<string>}
    */
   static +filters: $ReadOnlyArray<string>;
   /**
+   * DataStore.settings
    * Get or set settings for the current plugin (as a JavaScript object).
    * Example: settings.shortcutExpenses[0].category
    * Note: Available from v3.3.2
    */
   static settings: Object;
   /**
+   * DataStore.teamspaces
    * DataStore.teamspaces returns an array of teamspaces represented as Note Objects with title and filename populated. Example of a filename: %%NotePlanCloud%%/275ce631-6c20-4f76-b5fd-a082a9ac5160
    * Note: No object for private notes is included here.
    * Note: Available from v3.17.0
@@ -1006,11 +1059,13 @@ declare class CommandBar {
   // Impossible constructor
   constructor(_: empty): empty;
   /**
+   * CommandBar.placeholder
    * Get or set the current text input placeholder (what you can read when no
    * input is typed in) of the Command Bar.
    */
   static placeholder: string;
   /**
+   * CommandBar.searchText
    * Get or set the current text input content of the Command Bar
    * (what the user normally types in).
    */
@@ -1174,6 +1229,7 @@ declare class Calendar {
   // Impossible constructor
   constructor(_: empty): empty;
   /**
+   * Calendar.dateUnits
    * Get all available date units: "year", "month", "day", "hour", "minute", "second"
    */
   static +dateUnits: $ReadOnlyArray<CalendarDateUnit>;
@@ -1391,79 +1447,96 @@ declare interface Paragraph {
   // Impossible to create Paragraphs manually
   constructor(_: empty): empty;
   /**
+   * Paragraph.type
    * Get or set the type of the paragraph
    */
   type: ParagraphType;
   /**
+   * Paragraph.note
    * Returns the NoteObject behind this paragraph. This is a convenience method, so you don't need to use DataStore.
    * Note: EM adds that "You could have the paragraph object in memory while the note was deleted in the background", which is why this is optional.
    * Note: Available from v3.5.2
    */
   +note: ?TNote;
   /**
+   * Paragraph.content
    * Get or set the content of the paragraph
    * (without the Markdown 'type' prefix, such as '* [ ]' for open task)
    */
   content: string;
   /**
+   * Paragraph.rawContent
    * Get the content of the paragraph
    * (with the Markdown 'type' prefix, such as '* [ ]' for open task)
    */
   +rawContent: string;
   /**
+   * Paragraph.prefix
    * Get the Markdown prefix of the paragraph (like '* [ ]' for open task).
    * Note: @jgclark thinks this does not include any indentation whitespace.
    */
   +prefix: string;
   /**
+   * Paragraph.contentRange
    * Get the range of the paragraph.
    * Note: this can become inaccurate if other content changes in the note; it is not automatically recalculated. Re-fetch paragraphs to avoid this.
    */
   +contentRange: TRange | void;
   /**
+   * Paragraph.lineIndex
    * Get the line index of the paragraph.
    * Note: this can become inaccurate if other content changes in the note; it is not automatically recalculated. Re-fetch paragraphs to avoid this.
    * WARNING: this can be different in `Editor` and `Note` contexts, even for the same paragraph, because frontmatter lines are not included in the `Editor` context since ~v3.16.3.
    */
   +lineIndex: number;
   /**
+   * Paragraph.date
    * Get the date of the paragraph, if any (in case of scheduled tasks).
    */
   +date: Date | void;
   /**
+   * Paragraph.heading
    * Get the heading of the paragraph (looks for a previous heading paragraph).
    */
   +heading: string;
   /**
+   * Paragraph.headingRange
    * Get the heading range of the paragraph
    * (looks for a previous heading paragraph).
    */
   +headingRange: TRange | void;
   /**
+   * Paragraph.headingLevel
    * Get the heading level of the paragraph ('# heading' = level 1).
    */
   +headingLevel: number;
   /**
+   * Paragraph.isRecurring
    * If the task is a recurring one (contains '@repeat(...)')
    */
   +isRecurring: boolean;
   /**
+   * Paragraph.indents
    * Get/Set the amount of indentations.
    */
   indents: number;
   /**
+   * Paragraph.filename
    * Get the filename of the note this paragraph was loaded from
    */
   +filename: ?string;
   /**
+   * Paragraph.noteType
    * Get the note type of the note this paragraph was loaded from.
    */
   +noteType: ?NoteType;
   /**
+   * Paragraph.linkedNoteTitles
    * Get the linked note titles this paragraph contains, such as '[[Note Name]]' (will return names without the brackets).
    */
   +linkedNoteTitles: $ReadOnlyArray<string>;
   /**
+   * Paragraph.duplicate()
    * Creates a duplicate object, so you can change values without affecting the original object
    */
   duplicate(): Paragraph;
@@ -1483,18 +1556,21 @@ declare interface Paragraph {
    */
   children(): $ReadOnlyArray<TParagraph> | void;
   /**
+   * Paragraph.referencedBlocks
    * Returns an array of all paragraphs having the same blockID (including this paragraph). You can use `paragraph[0].note` to access the note behind it and make updates via `paragraph[0].note.updateParagraph(paragraph[0])` if you make changes to the content, type, etc (like checking it off as type = "done")
    * Note: Available from v3.5.2
    * @type {[TParagraph]} - getter
    */
   +referencedBlocks: [TParagraph];
   /**
+   * Paragraph.note
    * Returns the NoteObject behind this paragraph. This is a convenience method, so you don't need to use DataStore.
    * Note: Available from v3.5.2
    * @type {TNote?}
    */
   +note: ?TNote;
   /**
+   * Paragraph.blockId
    * Returns the given blockId if any.
    * WARNING: This has a different capitalisation than '.addBlockID'
    * Note: Available from v3.5.2
@@ -1515,11 +1591,13 @@ type NoteType = 'Calendar' | 'Notes'
  */
 declare interface Note extends CoreNoteFields {
   /**
+   * Note.linkedItems
    * Get paragraphs contained in this note which contain a link to another [[project note]] or [[YYYY-MM-DD]] daily note.
    * Note: Available from v3.2.0
    */
   +linkedItems: $ReadOnlyArray<TParagraph>;
   /**
+   * Note.datedTodos
    * Get paragraphs contained in this note which contain a link to a daily note.
    * Specifically this includes paragraphs with >YYYY-MM-DD, @YYYY-MM-DD, <YYYY-MM-DD, >today, @done(YYYY-MM-DD HH:mm), but only in non-calendar notes (because currently NotePlan doesn't create references between daily notes).
    * Note: Available from v3.2.0
@@ -1726,6 +1804,7 @@ declare class Clipboard {
    */
   static string: string;
   /**
+   * Clipboard.types
    * Returns a list of types.
    */
   static +types: $ReadOnlyArray<string>;
@@ -1828,20 +1907,24 @@ type TCalendarFilename = string
 type TCoreNoteFields = CoreNoteFields
 declare interface CoreNoteFields {
   /**
+   * [Editor|Note].title
    * Title = first line of the note. (NB: Getter only.)
    */
   +title: string | void;
   /**
+   * [Editor|Note].type
    * Type of the note, either "Notes" or "Calendar".
    */
   +type: NoteType;
   /**
+   * [Editor|Note].filename
    * Get the filename of the note.
    * Folder + Filename of the note (the path is relative to the root of the chosen storage location)
    * From v3.6.0 can also *set* the filename, which does a rename.
    */
   filename: string /* Idea: TRegularFilename | TCalendarFilename; */;
   /**
+   * [Editor|Note].resolvedFilename
    * Returns the relative, resolved path of the note (including the folder, like `folder/filename.txt`).
    * If it's a teamspace note, it replaces the IDs in the path with the name of the teamspace and the name of the note. Teamspace note filenames end otherwise with an ID, and the teamspace is also represented as an ID.
    * Note: Don't use this filename to read or write the note. Use `.filename`, instead.
@@ -1850,32 +1933,38 @@ declare interface CoreNoteFields {
    */
   +resolvedFilename: string;
   /**
+   * [Editor|Note].date
    * Optional date if it's a calendar note
    * WARNING: As of 3.18.2 b1428 this is not available in Editor.
    */
   +date: Date | void;
   /**
+   * [Editor|Note].changedDate
    * Date and time when the note was last modified.
    * WARNING: As of 3.18.2 b1428 this is not available in Editor.
    */
   +changedDate: Date;
   /**
+   * [Editor|Note].createdDate
    * Date and time of the creation of the note.
    * WARNING: As of 3.18.2 b1428 this is not available in Editor.
    */
   +createdDate: Date;
   /**
+   * [Editor|Note].hashtags
    * All #hashtags contained in this note.
    * WARNING: As of 3.18.2 b1428 this is not available in Editor.
    */
   +hashtags: $ReadOnlyArray<string>;
   /**
+   * [Editor|Note].mentions
    * All @mentions contained in this note.
    * WARNING: @jgclark experience shows that can be unreliable, sometimes not returning any entries when it should.
    * WARNING: As of 3.18.2 b1428 this is not available in Editor.
    */
   +mentions: $ReadOnlyArray<string>;
   /**
+   * [Editor|Note].content
    * Get or set the raw text of the note (without hiding or rendering any Markdown).
    * If you set the content, NotePlan will write it immediately to file.
    * If you get the content, it will be read directly from the file.
@@ -1883,12 +1972,14 @@ declare interface CoreNoteFields {
    */
   content: string | void;
   /**
+   * [Editor|Note].paragraphs
    * Get or set the array of paragraphs contained in this note, such as tasks, bullets, etc.
    * If you set the paragraphs, the content of the note will be updated.
    * WARNING: From ~v3.16.3, Editor.paragraphs and Editor.note.paragraphs can be different, with Editor.paragraphs not including the frontmatter lines.
    */
   paragraphs: Array<TParagraph>;
   /**
+   * [Editor|Note].backlinks
    * Get all backlinks pointing to the current note as Paragraph objects. In this array, the toplevel items are all notes linking to the current note and the 'subItems' attributes (of the paragraph objects) contain the paragraphs with a link to the current note. The heading of the linked paragraphs are also listed here, although they don't have to contain a link.
    * NB: Backlinks are all [[note name]] and >date links.
    * TODO(@nmn): Please include `subItems` here
@@ -1896,6 +1987,7 @@ declare interface CoreNoteFields {
    */
   +backlinks: $ReadOnlyArray<TBacklinkNoteFields>;
   /**
+   * [Editor|Note].publicRecordID
    * Returns the database record ID of the published note (on CloudKit). Returns null if the note is not published yet.
    * Use this to verify if a note has been published and to build the public link: https://noteplan.co/n/{publicRecordID}
    * Note: Available from v3.9.1
@@ -1903,12 +1995,14 @@ declare interface CoreNoteFields {
    */
   +publicRecordID: ?string;
   /**
+   * [Editor|Note].conflictedVersion
    * Returns the conflicted version if any, including 'url' which is the path to the file. Otherwise, returns undefined.
    * Note: Available from v3.9.3
    * @return { Object(filename: string, url: string, content: string) }
    */
   +conflictedVersion: Object;
   /**
+   * [Editor|Note].versions
    * Get all available versions of a note from the backup database. It returns an array with objects that have following attributes: `content` (full content of the note) and `date` (when this version was saved).
    * You can use this in combination with note triggers and diffs to figure out what has changed inside the note.
    * The first entry in the array is the current version and the second contains the content of the previous version, etc.
@@ -1916,12 +2010,14 @@ declare interface CoreNoteFields {
    */
   +versions: $ReadOnlyArray<string, Date>;
   /**
+   * [Editor|Note].frontmatterTypes
    * Get all 'type's assigned to this note in the frontmatter as an array of strings.
    * You can set types of a note by adding frontmatter e.g. `type: meeting-note, empty-note` (comma separated).
    * Note: Available on Note from v3.5.0, but only on Editor from v3.16.3.
    */
   +frontmatterTypes: $ReadOnlyArray<string>;
   /**
+   * [Editor|Note].frontmatterAttributes
    * Returns the frontmatter key-value pairs inside the note. To set a frontmatter attribute, use setFrontmatterAttribute.
    * You can also use the setter, but you will need to first read the complete frontmatter object (key-value pairs), change it and then set it. Otherwise the setter *won't* be triggered if you set it directly like `frontmatterAttributes["key"] = "value"`. This is more useful if you want to set multiple frontmatter values.
    * Note: @dbwertheimer says "Returns {} if no frontmatter stripes or if there are stripes but no attributes."
@@ -1931,6 +2027,7 @@ declare interface CoreNoteFields {
    */
   +frontmatterAttributes: Object;
   /**
+   * [Editor|Note].updateFrontmatterAttributes()
    * Updates multiple frontmatter attributes at once in a single operation.
    * More efficient than calling setFrontmatterAttribute multiple times as it only reads and writes the note content once.
    * Each attribute object should have "key" and "value" properties.
@@ -1947,6 +2044,7 @@ declare interface CoreNoteFields {
   updateFrontmatterAttributes(attributes: Array<{ key: string, value: string }>): void;
 
   /**
+   * [Editor|Note].rename()
    * Renames the note. You can also define a folder path. The note will be moved to that folder and the folder will be automatically created.
    * If the filename already exists, a number will be appended. If the filename begins with ".", it will be removed.
    * It returns the actual filename.
@@ -2221,6 +2319,7 @@ declare class NotePlan {
   // Impossible constructor.
   constructor(_: empty): empty;
   /**
+   * NotePlan.environment
    * Returns the environment information from the operating system:
    * Available from v3.3.2:
    *   .languageCode: string?
@@ -2271,6 +2370,7 @@ declare class NotePlan {
    */
   static ai(prompt: string, filenames: Array<string>, useStrictFilenames: boolean, model?: string): Promise<string>;
   /**
+   * NotePlan.selectedSidebarFolder
    * The selected sidebar folder (useful when a note is not showing in Editor, which is then null)
    * Note: available from v3.5.1
    */
@@ -2304,12 +2404,14 @@ declare class NotePlan {
    */
   static stringDiff(version1: string, version2: string): Array<TRange>;
   /**
+   * NotePlan.editors
    * Returns a list of all opened editors (in the main view, in split views and in floating windows). See more details in the "Editor" documentation.
    * Note: Available from v3.8.1 build 973
    * @returns {Array<TEditor>}
    */
   static +editors: Array<TEditor>;
   /**
+   * NotePlan.htmlWindows
    * Returns a list of all opened HTML windows.
    * Note: Available from v3.8.1 build 973
    * @returns {Array<HTMLView>}

--- a/flow-typed/Noteplan.js
+++ b/flow-typed/Noteplan.js
@@ -59,7 +59,7 @@ declare interface TEditor extends CoreNoteFields {
   +selectedLinesText: $ReadOnlyArray<string>;
   /**
    * Get an array of selected paragraphs. The cursor doesn't have to select the
-   * full paragraph, NotePlan returns all complete paragraphs the cursor "touches". 
+   * full paragraph, NotePlan returns all complete paragraphs the cursor "touches".
    * Note: not all of the paragraph object data is complete, e.g. "headingLevel", "heading" and other properties may not be set properly.
    * Use the result and a map to get all the correct data, e.g.:
    * const selectedParagraphs = Editor.selectedParagraphs.map((p) => Editor.paragraphs[p.lineIndex])
@@ -67,14 +67,14 @@ declare interface TEditor extends CoreNoteFields {
    */
   +selectedParagraphs: $ReadOnlyArray<TParagraph>;
   /**
-   * Get the raw selection range (hidden Markdown is considered). 
+   * Get the raw selection range (hidden Markdown is considered).
    * Note: frontmatter is not included in the character counts, since ~v3.16.3
    */
-+selection: ?TRange;
+  +selection: ?TRange;
   /**
    * Get the rendered selection range (hidden Markdown is NOT considered).
    */
-+renderedSelection: ?TRange;
+  +renderedSelection: ?TRange;
   /**
    * Get the selected text.
    */
@@ -119,8 +119,8 @@ declare interface TEditor extends CoreNoteFields {
     splitView?: boolean,
     createIfNeeded?: boolean,
     content?: string,
-    stayInSpace ?: boolean,
-  ): Promise < TNote | void>;
+    stayInSpace?: boolean,
+  ): Promise<TNote | void>;
   /**
    * Opens a note by searching for the give title (first line of the note)
    * Note: 'splitView' parameter available for macOS from v3.4
@@ -164,7 +164,7 @@ declare interface TEditor extends CoreNoteFields {
    * @param {string?} parent - (optional) to specify UUID of Teamspace to look in
    * @return {Promise<TNote>} - When the note has been opened, a promise will be returned
    */
-openNoteByDate(date: Date, newWindow ?: boolean, highlightStart ?: number, highlightEnd ?: number, splitView ?: boolean, timeframe ?: string, parent ?: string): Promise < TNote | void>;
+  openNoteByDate(date: Date, newWindow?: boolean, highlightStart?: number, highlightEnd?: number, splitView?: boolean, timeframe?: string, parent?: string): Promise<TNote | void>;
   /**
    * Opens a calendar note by the given date string.
    * @param {string} dateString - The date string that should be opened, in ISO format ("YYYY-MM-DD") or filename format for days ("YYYYMMDD") or (from v3.6) in "YYYY-Wnn" format for weeks
@@ -404,15 +404,15 @@ openNoteByDate(date: Date, newWindow ?: boolean, highlightStart ?: number, highl
    * @param {boolean}
    */
   skipNextRepeatDeletionCheck: boolean;
-/**
-* Sets a frontmatter attribute with the given key and value.
-* If the key already exists, updates its value. If it doesn't exist, adds a new key-value pair.
-* To set multiple frontmatter attributes, use frontmatterAttributes = key-value object.
-* @param {string} key - The frontmatter key to set
-* @param {string} value - The value to set for the key
-* Note: Available from v3.17 - only for Editor!
-*/
-setFrontmatterAttribute(key: string, value: string): void;
+  /**
+   * Sets a frontmatter attribute with the given key and value.
+   * If the key already exists, updates its value. If it doesn't exist, adds a new key-value pair.
+   * To set multiple frontmatter attributes, use frontmatterAttributes = key-value object.
+   * @param {string} key - The frontmatter key to set
+   * @param {string} value - The value to set for the key
+   * Note: Available from v3.17 - only for Editor!
+   */
+  setFrontmatterAttribute(key: string, value: string): void;
 }
 
 /**
@@ -435,6 +435,7 @@ declare class DataStore {
    */
   static +folders: $ReadOnlyArray<string>;
   /**
+   * DataStore.createFolder()
    * Create folder, if it doesn't already exist.
    * e.g. `DataStore.createFolder("test/hello world")`
    * Returns true if created OK (or it already existed) and false otherwise.
@@ -476,7 +477,7 @@ declare class DataStore {
    * Note: Available from v3.6.0
    * @type {Array<string>}
    */
-static + filters: $ReadOnlyArray < string >;
+  static +filters: $ReadOnlyArray<string>;
   /**
    * Get or set settings for the current plugin (as a JavaScript object).
    * Example: settings.shortcutExpenses[0].category
@@ -488,9 +489,10 @@ static + filters: $ReadOnlyArray < string >;
    * Note: No object for private notes is included here.
    * Note: Available from v3.17.0
    */
-  static teamspaces: $ReadOnlyArray < TNote >;
+  static teamspaces: $ReadOnlyArray<TNote>;
 
   /**
+   * DataStore.preference()
    * Returns the value of a given preference.
    * Available keys for built-in NotePlan preferences:
    *   "themeLight"              // theme used in light mode
@@ -517,6 +519,7 @@ static + filters: $ReadOnlyArray < string >;
    */
   static +preference: (key: string) => mixed;
   /**
+   * DataStore.setPreference()
    * Change a saved preference or create a new one.
    * It will most likely be picked up by NotePlan after a restart, if you use one of the keys utilized by NotePlan.
    *
@@ -530,6 +533,7 @@ static + filters: $ReadOnlyArray < string >;
    */
   static setPreference(key: string, value: mixed): void;
   /**
+   * DataStore.saveJSON()
    * Save a JavaScript object to the Plugins folder as JSON file.
    * This can be used to save preferences or other persistent data.
    * It's saved automatically into a new folder "data" in the Plugins folder.
@@ -542,6 +546,7 @@ static + filters: $ReadOnlyArray < string >;
    */
   static saveJSON(object: Object, filename?: string, shouldBlockUpdate?: boolean): boolean;
   /**
+   * DataStore.loadJSON()
    * Load a JavaScript object from a JSON file located (by default) in the <Plugin>/data folder.
    * But you can also use relative paths: ../Plugins/<folder or filename>.
    * Note: this can return a single string within the object, and so may need to be JSON.parse()d.
@@ -551,6 +556,7 @@ static + filters: $ReadOnlyArray < string >;
    */
   static loadJSON(filename?: string): Object;
   /**
+   * DataStore.saveData()
    * Save data to a file.
    * Can use this with base64 encoding to save arbitary binary data, or with string-based data (using loadAsString flag).
    * The file will be saved under "[NotePlan Folder]/Plugins/data/[plugin-id]/[filename]".
@@ -564,6 +570,7 @@ static + filters: $ReadOnlyArray < string >;
    */
   static saveData(data: string, filename: string, loadAsString: boolean): boolean;
   /**
+   * DataStore.loadData()
    * Load data from a file.
    * Can be used with saveData() to save and load binary data from encoded as a base64 string, or string-based data (using loadAsString flag).
    * The file has to be located in "[NotePlan Folder]/Plugins/data/[plugin-id]/[filename]".
@@ -576,12 +583,14 @@ static + filters: $ReadOnlyArray < string >;
    */
   static loadData(filename: string, loadAsString: boolean): ?string;
   /**
+   * DataStore.listOverdueTasks()
    * Get list of all overdue tasks as paragraphs
    * Note: Available from v3.8.1
    * @type {Array<TParagraph>}
    */
-  static listOverdueTasks(): $ReadOnlyArray < TParagraph >;
+  static listOverdueTasks(): $ReadOnlyArray<TParagraph>;
   /**
+   * DataStore.fileExists()
    * Check to see if a file in the available folders exists.
    * It starts in the plugin's own data folder, but can be used to check for files in other folders.
    * Note: Available from v3.8.1
@@ -590,6 +599,7 @@ static + filters: $ReadOnlyArray < string >;
    */
   static fileExists(filename: string): boolean;
   /**
+   * DataStore.calendarNoteByDate()
    * Returns the calendar note for the given date and timeframe (optional, the default is "day", see below for more options).
    * Note: from v3.17.0, this includes Teamspace calendar notes. Calendar Notes are represented with the ISO date + extension in the path.
    * Note: 'timeframe' available from v3.6.0
@@ -601,8 +611,9 @@ static + filters: $ReadOnlyArray < string >;
    * @param {string?} parent: Teamspace (if relevant) = the ID or filename of the teamspace it belongs to. If left undefined, the private calendar note will be returned as before.
    * @returns {NoteObject}
    */
-  static calendarNoteByDate(date: Date, timeframe ?: string, parent ?: string): ?TNote;
+  static calendarNoteByDate(date: Date, timeframe?: string, parent?: string): ?TNote;
   /**
+   * DataStore.calendarNoteByDateString()
    * Returns the calendar note for the given date string (can be undefined, if the calendar note was not created yet). See the date formats below for various types of calendar notes:
    * Daily: "YYYYMMDD", example: "20210410" or "YYYY-MM-DD", example: "2021-04-10"
    * Weekly: "YYYY-Wwn", example: "2022-W24"
@@ -618,8 +629,9 @@ static + filters: $ReadOnlyArray < string >;
    * @param {TTeamspaceID? | string?} parent: Teamspace (if relevant) = the ID or filename of the teamspace it belongs to. If left undefined, the private calendar note will be returned as before.
    * @returns {NoteObject}
    */
-  static calendarNoteByDateString(dateString: string, parent ?: TTeamspaceID | string): ?TNote;
+  static calendarNoteByDateString(dateString: string, parent?: TTeamspaceID | string): ?TNote;
   /**
+   * DataStore.projectNoteByTitle()
    * Returns all regular notes with the given title.
    * Since multiple notes can have the same title, an array is returned.
    * Use 'caseSensitive' (default = false) to search for a note ignoring
@@ -629,17 +641,20 @@ static + filters: $ReadOnlyArray < string >;
    */
   static projectNoteByTitle(title: string, caseInsensitive?: boolean, searchAllFolders?: boolean): ?$ReadOnlyArray<TNote>;
   /**
+   * DataStore.projectNoteByTitleCaseInsensitive()
    * Returns all regular notes with the given case insensitive title.
    * Note: Since multiple notes can have the same title, an array is returned.
    */
   static projectNoteByTitleCaseInsensitive(title: string): ?$ReadOnlyArray<TNote>;
   /**
+   * DataStore.projectNoteByFilename()
    * Returns the regular note with the given filename (including file-extension).
    * The filename has to include the relative folder such as folder/filename.txt` but without leading slash. Use no leading slash if it's in the root folder.
    * WARNING: @jgclark reports that this doesn't work for Teamspace notes.
    */
   static projectNoteByFilename(filename: string): ?TNote;
   /**
+   * DataStore.noteByFilename()
    * Returns a regular or calendar note for the given filename. Type can be "Notes" or "Calendar". Include relative folder and file extension (`folder/filename.txt` for example).
    * Use "YYYYMMDD.ext" for calendar notes, like "20210503.txt".
    * Note: 'parent' available from v3.17.0
@@ -648,8 +663,9 @@ static + filters: $ReadOnlyArray < string >;
    * @param {string?} parent: Teamspace (if relevant) = the ID or filename of the teamspace it belongs to. Applies only to calendar notes.
    * @returns {?TNote}
    */
-  static noteByFilename(filename: string, type: NoteType, parent ?: string): ?TNote;
+  static noteByFilename(filename: string, type: NoteType, parent?: string): ?TNote;
   /**
+   * DataStore.moveNote()
    * Move a regular note using the given filename (with extension) to another folder. Use "/" for the root folder.
    * Note: Can also move *folders* by specifying its filename (without trailing slash).
    * Note: You can also use this to delete notes or folders by moveNote(filepath, '@Trash'). @jgclark adds that @EM confirmed on 2025-08-05 that this doesn't work for Teamspace notes (at least as of v3.18.1).
@@ -662,6 +678,7 @@ static + filters: $ReadOnlyArray < string >;
    */
   static moveNote(filename: string, folder: string, type?: NoteType): ?string;
   /**
+   * DataStore.newNote()
    * Creates a regular note using the given title and folder.
    * Use "/" for the root folder.
    * It will write the given title as "# title" into the new file.
@@ -673,6 +690,7 @@ static + filters: $ReadOnlyArray < string >;
    */
   static newNote(noteTitle: string, folder: string): ?string;
   /**
+   * DataStore.newNoteWithContent()
    * Creates a regular note using the given content, folder and filename. Use "/" for the root folder.
    * The content should ideally also include a note title at the top.
    * Returns the final filename with relative folder (`folder/filename.txt` for example).
@@ -687,6 +705,7 @@ static + filters: $ReadOnlyArray < string >;
   static newNoteWithContent(content: string, folder: string, filename?: string): string;
 
   /**
+   * DataStore.referencedBlocks()
    * Returns an array of paragraphs having the same blockID like the given one (which is also part of the return array).
    * Note: @jgclark comments that this use does *not* appear to return the original paragraph in the array. (At least from 2023 to mid 2025.)
    * Or use without an argument to return all paragraphs with blockIDs.
@@ -699,6 +718,7 @@ static + filters: $ReadOnlyArray < string >;
   static referencedBlocks(paragraph: TParagraph): Array<TParagraph>;
 
   /**
+   * DataStore.updateCache()
    * Updates the cache, so you can access changes faster.
    * 'shouldUpdateTags' parameter controls whether to update .hashtags and .mentions too.
    * EM also commented "[and] things like .backlinks".
@@ -713,6 +733,7 @@ static + filters: $ReadOnlyArray < string >;
   static updateCache(note: TNote, shouldUpdateTags: boolean): TNote | null;
 
   /**
+   * DataStore.listPlugins()
    * Loads all available plugins asynchronously from the GitHub repository and returns a list.
    * Note: Available from NotePlan v3.5.2; 'skipMatchingLocalPlugins' added v3.7.2 build 926
    * @param {boolean} showLoading? - You can show a loading indicator using the first parameter (true) if this is part of some user interaction. Otherwise, pass "false" so it happens in the background.
@@ -722,6 +743,7 @@ static + filters: $ReadOnlyArray < string >;
    */
   static listPlugins(showLoading?: boolean, showHidden?: boolean, skipMatchingLocalPlugins?: boolean): Promise<Array<PluginObject>>;
   /**
+   * DataStore.installPlugin()
    * Installs a given plugin (load a list of plugins using `.listPlugins` first). If this is part of a user interfaction, pass "true" for `showLoading` to show a loading indicator.
    * Note: Available from v3.5.2
    * @param {PluginObject}
@@ -730,12 +752,14 @@ static + filters: $ReadOnlyArray < string >;
    */
   static installPlugin(pluginObject: PluginObject, showLoading?: boolean): Promise<PluginObject>;
   /**
+   * DataStore.installedPlugins()
    * Returns all installed plugins as PluginObject(s).
    * Note: Available from v3.5.2
    * @return {Array<PluginObject>}
    */
   static installedPlugins(): Array<PluginObject>;
   /**
+   * DataStore.invokePluginCommand()
    * Invoke a given command from a plugin (load a list of plugins using `.listPlugins` first, then get the command from the `.commands` list).
    * If the command supports it, you can also pass an array of arguments which can contain any type (object, date, string, integer,...)
    * It returns the particular return value of that command which can be a Promise so you can use it with `await`.
@@ -747,6 +771,7 @@ static + filters: $ReadOnlyArray < string >;
    */
   static invokePluginCommand(command: PluginCommandObject, arguments: $ReadOnlyArray<mixed>): Promise<any>;
   /**
+   * DataStore.invokePluginCommandByName()
    * Invoke a given command from a plugin using the name and plugin ID, so you don't need to load it from the list.
    * If the command doesn't exist locally null will be returned with a log message.
    * If the command supports it, you can also pass an array of arguments which can contain any type (object, date, string, integer,...)
@@ -759,6 +784,7 @@ static + filters: $ReadOnlyArray < string >;
    */
   static invokePluginCommandByName(commandName: string, pluginID: string, arguments?: $ReadOnlyArray<mixed>): Promise<any>;
   /**
+   * DataStore.isPluginInstalledByID()
    * Checks if the given pluginID is installed or not.
    * Note: Available from v3.6.0
    * @param {string}
@@ -766,6 +792,7 @@ static + filters: $ReadOnlyArray < string >;
    */
   static isPluginInstalledByID(pluginID: string): boolean;
   /**
+   * DataStore.installOrUpdatePluginsByID()
    * Installs a given array of pluginIDs if needed. It checks online if a new version is available and downloads it.
    * Use it without `await` so it keeps running in the background or use it with `await` in "blocking mode" if you need to install a plugin as a dependency. In this case you can use `showPromptIfSuccessful = true` to show the user a message that a plugin was installed and `showProgressPrompt` will show a loading indicator beforehand. With both values set to false or not defined it will run in "silent" mode and show no prompts.
    * returns an object with an error code and a message { code: -1, message: "something went wrong" } for example. Anything code >= 0 is a success.
@@ -784,6 +811,7 @@ static + filters: $ReadOnlyArray < string >;
   ): Promise<{ code: number, message: string }>;
 
   /**
+   * DataStore.search()
    * Searches all notes for a keyword (uses multiple threads to speed it up).
    * By default it searches in project notes and in the calendar notes. Use the second parameters "typesToInclude" to include specific types. Otherwise, pass `null` or nothing to include all of them.
    * This function is async, use it with `await`, so that the UI is not being blocked during a long search.
@@ -808,6 +836,7 @@ static + filters: $ReadOnlyArray < string >;
   ): Promise<$ReadOnlyArray<TParagraph>>;
 
   /**
+   * DataStore.searchProjectNotes()
    * Searches all project notes for a keyword (uses multiple threads to speed it up).
    * This function is async, use it with `await`, so that the UI is not being blocked during a long search.
    * Optionally pass a list of folders (`inNotes`) to limit the search to notes that ARE in those folders (applies only to project notes)
@@ -822,6 +851,7 @@ static + filters: $ReadOnlyArray < string >;
   static searchProjectNotes(keyword: string, inFolders?: Array<string>, notInFolders?: Array<string>): Promise<$ReadOnlyArray<TParagraph>>;
 
   /**
+   * DataStore.searchCalendarNotes()
    * Searches all calendar notes for a keyword (uses multiple threads to speed it up).
    * This function is async, use it with `await`, so that the UI is not being blocked during a long search.
    * Note: Available from v3.6.0
@@ -831,23 +861,25 @@ static + filters: $ReadOnlyArray < string >;
    */
   static searchCalendarNotes(keyword?: string, shouldLoadDatedTodos?: boolean): Promise<$ReadOnlyArray<TParagraph>>;
   /**
+   * DataStore.listOverdueTasks()
    * Returns list of all overdue tasks (i.e. tasks that are open and in the past). Use with await, it runs in the background. If there are a lot of tasks consider showing a loading bar.
    * Note: this does not include open checklist items.
    * Note: Available from v3.8.1
    * @param {string} = keyword to search for
    * @return {$ReadOnlyArray<TParagraph>} Promise to array of results
    */
-  static listOverdueTasks(keyword: string): Promise < $ReadOnlyArray < TParagraph >>;
+  static listOverdueTasks(keyword: string): Promise<$ReadOnlyArray<TParagraph>>;
   /**
-  * Move a regular note using the given filename (include extension and relative folder like `folder/filename.txt`, if it's in the root folder don't add a leading slash) to the trash folder. 
-  * Returns true if successful.
-  * Note: Calendar notes cannot be moved to trash.
-  * Note: Teamspace notes are deleted immediately (teamspaces have no trash folder as of now), but a copy is made inside the system trash bin, if the user needs to recover the note.
-  * Note: available from v3.18.2 b1431
-  * @param {string} 
-  * @return {boolean}
-  */
-trashNote(filename: string): boolean;
+   * DataStore.trashNote()
+   * Move a regular note using the given filename (include extension and relative folder like `folder/filename.txt`, if it's in the root folder don't add a leading slash) to the trash folder.
+   * Returns true if successful.
+   * Note: Calendar notes cannot be moved to trash.
+   * Note: Teamspace notes are deleted immediately (teamspaces have no trash folder as of now), but a copy is made inside the system trash bin, if the user needs to recover the note.
+   * Note: available from v3.18.2 b1431
+   * @param {string}
+   * @return {boolean}
+   */
+  trashNote(filename: string): boolean;
 }
 
 /**
@@ -984,43 +1016,46 @@ declare class CommandBar {
    */
   static searchText: string;
   /**
+   * CommandBar.hide()
    * Hides the Command Bar
    */
   static hide(): void;
   // show(): void,
   /**
-  * Display an array of choices as a list which the user can "fuzzy-search" filter by typing something.
-  * The result is a CommandBarResultObject (as Promise success result), which has ".value" and ".index".
-  * 
-  * Options can be provided in two formats:
-  * 1. String array (for backward compatibility): ["Option 1", "Option 2", ...]
-  * 2. Object array (available from v3.18) with properties:
-  *    - text: string (required) - The display text
-  *    - icon: string (optional) - Icon to display (FontAwesome icon name)
-  *    - shortDescription: string (optional) - Text displayed on the right side (for display only, can be used as description or to show a shortut key - though does not provide actual keyboard shortcut functionality)
-  *    - color: string (optional) - Color for the icon (hex like "#FF0000" or tailwind color name)
-  *    - shortcutColor: string (optional) - Color for the shortcut text (hex or tailwind)
-  *    - alpha: number (optional) - Opacity for light theme (0-1). Default opacity will be used if not specified
-  *    - darkAlpha: number (optional) - Opacity for dark theme (0-1). Default opacity will be used if not specified
-  * 
-  * Example object format:
-  * [
-  *   { text: "Option 1", icon: "star", color: "#FFD700" },
-  *   { text: "Option 2", icon: "check", shortcut: "Premium", shortcutColor: "#00FF00" },
-  *   { text: "Option 3", icon: "info", shortcut: "Beta feature", alpha: 0.8, darkAlpha: 0.9 }
-  * ]
-  * 
-  * Use the ".index" attribute to refer back to the selected item in the original array.
-  * If you want to provide an existing search text that will be inserted into the command bar, use the third parameter.
-  * Note: The user selection is returned as a Promise. So use it with "await CommandBar.showOptions(...)".
-  * 
-  * @param {[String]|[TCommandBarOptionObject]} options - Array of strings or objects with options
-  * @param {String} placeholder - Placeholder text for the search input
-  * @param {String} searchText - Initial search text to populate
-  * @returns {Promise<TCommandBarResultObject>} - Promise resolving to result with .value, .index, and .keyModifiers
-  */
+   * CommandBar.showOptions()
+   * Display an array of choices as a list which the user can "fuzzy-search" filter by typing something.
+   * The result is a CommandBarResultObject (as Promise success result), which has ".value" and ".index".
+   *
+   * Options can be provided in two formats:
+   * 1. String array (for backward compatibility): ["Option 1", "Option 2", ...]
+   * 2. Object array (available from v3.18) with properties:
+   *    - text: string (required) - The display text
+   *    - icon: string (optional) - Icon to display (FontAwesome icon name)
+   *    - shortDescription: string (optional) - Text displayed on the right side (for display only, can be used as description or to show a shortut key - though does not provide actual keyboard shortcut functionality)
+   *    - color: string (optional) - Color for the icon (hex like "#FF0000" or tailwind color name)
+   *    - shortcutColor: string (optional) - Color for the shortcut text (hex or tailwind)
+   *    - alpha: number (optional) - Opacity for light theme (0-1). Default opacity will be used if not specified
+   *    - darkAlpha: number (optional) - Opacity for dark theme (0-1). Default opacity will be used if not specified
+   *
+   * Example object format:
+   * [
+   *   { text: "Option 1", icon: "star", color: "#FFD700" },
+   *   { text: "Option 2", icon: "check", shortcut: "Premium", shortcutColor: "#00FF00" },
+   *   { text: "Option 3", icon: "info", shortcut: "Beta feature", alpha: 0.8, darkAlpha: 0.9 }
+   * ]
+   *
+   * Use the ".index" attribute to refer back to the selected item in the original array.
+   * If you want to provide an existing search text that will be inserted into the command bar, use the third parameter.
+   * Note: The user selection is returned as a Promise. So use it with "await CommandBar.showOptions(...)".
+   *
+   * @param {[String]|[TCommandBarOptionObject]} options - Array of strings or objects with options
+   * @param {String} placeholder - Placeholder text for the search input
+   * @param {String} searchText - Initial search text to populate
+   * @returns {Promise<TCommandBarResultObject>} - Promise resolving to result with .value, .index, and .keyModifiers
+   */
   static showOptions(options: $ReadOnlyArray<string | TCommandBarOptionObject>, placeholder: string, searchText?: string): Promise<TCommandBarResultObject>;
   /**
+   * CommandBar.showInput()
    * Asks the user to enter something into the CommandBar.
    * Use the "placeholder" value to display a question, like "Type the name of the task".
    * Use the "submitText" to describe what happens with the selection, like "Create task named '%@'".
@@ -1035,6 +1070,7 @@ declare class CommandBar {
    */
   static showInput(placeholder: string, submitText: string): Promise<string>;
   /**
+   * CommandBar.showLoading()
    * Shows or hides a window with a loading indicator or a progress ring (if progress is defined) and an info text (optional).
    * `text` is optional, if you define it, it will be shown below the loading indicator.
    * `progress` is also optional. If it's defined, the loading indicator will change into a progress ring. Use float numbers from 0-1 to define how much the ring is filled.
@@ -1046,6 +1082,7 @@ declare class CommandBar {
    */
   static showLoading(visible: boolean, text?: string, progress?: number): void;
   /**
+   * CommandBar.onAsyncThread()
    * If you call this, anything after `await CommandBar.onAsyncThread()` will run on an asynchronous thread.
    * Use this together with `showLoading`, so that the work you do is not blocking the user interface.
    * Otherwise the loading window will be also blocked.
@@ -1057,6 +1094,7 @@ declare class CommandBar {
    */
   static onAsyncThread(): Promise<void>;
   /**
+   * CommandBar.onMainThread()
    * If you call this, anything after `await CommandBar.onMainThread()` will run on the main thread.
    * Call this after `onAsyncThread`, once your background work is done.
    * It is safe to call Editor and other user interface functions on the main thread.
@@ -1065,6 +1103,7 @@ declare class CommandBar {
   static onMainThread(): Promise<void>;
 
   /**
+   * CommandBar.prompt()
    * Show a native alert or confirm with title and message
    * Define at least one or more buttons for the user to select.
    * If you don't supply any buttons, an "OK" button will be displayed.
@@ -1077,6 +1116,7 @@ declare class CommandBar {
   static prompt(title: string, message: string, buttons?: $ReadOnlyArray<string>): Promise<number>;
 
   /**
+   * CommandBar.textPrompt()
    * Show a native text input prompt to the user with title and message text.
    * The buttons will be "OK" and "Cancel".
    * You can supply a default value which will be pre-filled.
@@ -1138,6 +1178,7 @@ declare class Calendar {
    */
   static +dateUnits: $ReadOnlyArray<CalendarDateUnit>;
   /**
+   * Calendar.availableCalendarTitles()
    * Get the titles of all calendars the user has access to. Set `writeOnly` true, if you want to get only the calendars the user has write access to (some calendars, like holidays are not writable).
    * Note: Available from v3.1
    * @param {boolean}
@@ -1145,18 +1186,21 @@ declare class Calendar {
    */
   static availableCalendarTitles(writeOnly: boolean): $ReadOnlyArray<string>;
   /**
+   * Calendar.availableReminderListTitles()
    * Get the titles of all reminders the user has access to.
    * Note: Available from v3.1
    * @return {Array<string>}
    */
   static availableReminderListTitles(): $ReadOnlyArray<string>;
   /**
+   * Calendar.add()
    * Create an event or reminder based on the given CalendarItem.
    * Returns the created CalendarItem with the assigned id, so you can
    * reference it later. If it failed, undefined is returned.
    */
   static add(item: TCalendarItem): TCalendarItem | void;
   /**
+   * Calendar.parseDateText()
    * Parses a text describing a text as natural language input into a date. Such as "today", "next week", "1st May", "at 5pm to 6pm", etc.
    * Returns an array with possible results (usually one), the most likely at the top.
    * The possible values that can be accessed are:
@@ -1178,41 +1222,49 @@ declare class Calendar {
    */
   static parseDateText(text: string): $ReadOnlyArray<ParsedTextDateRange>;
   /**
+   * Calendar.dateFrom()
    * Create a date object from parts. Like year could be 2021 as a number.
    * Note: month uses Swift counting (1-12) not Javascript counting (0-11).
    */
   static dateFrom(year: number, month: number, day: number, hour: number, minute: number, second: number): Date;
   /**
+   * Calendar.addUnitToDate()
    * Add a unit to an existing date. Look up all unit types using `dateUnits`.
    * For example, to add 10 days, use num = 10 and type = "day"
    */
   static addUnitToDate(date: Date, unit: CalendarDateUnit, num: number): Date;
   /**
+   * Calendar.unitOf()
    * Returns the integer of a unit like "year" (should be this year's number).
    * Look up all unit types using `dateUnits`.
    */
   static unitOf(date: Date, type: CalendarDateUnit): number;
   /**
+   * Calendar.timeAgoSinceNow()
    * Returns a description of how much time has past between the date and
    * today = now.
    */
   static timeAgoSinceNow(date: Date): string;
   /**
+   * Calendar.unitsUntilNow()
    * Returns the amount of units between the given date and now. Look up all
    * unit types using `dateUnits`.
    */
   static unitsUntilNow(date: Date, type: CalendarDateUnit): number;
   /**
+   * Calendar.unitsAgoFromNow()
    * Returns the amount of units from now and the given date. Look up all unit
    * types using `dateUnits`.
    */
   static unitsAgoFromNow(date: Date, type: CalendarDateUnit): number;
   /**
+   * Calendar.unitsBetween()
    * Returns the amount of units between the first and second date. Look up all
    * unit types using `dateUnits`.
    */
   static unitsBetween(date1: Date, date2: Date, type: CalendarDateUnit): number;
   /**
+   * Calendar.eventsBetween()
    * Returns all events between the `startDate` and `endDate`. Use `filter` to search for specific events (keyword in the title).
    * This function fetches events asynchronously, so use async/await.
    * Note: Available from v3.0.25
@@ -1223,6 +1275,7 @@ declare class Calendar {
    */
   static eventsBetween(startDate: Date, endDate: Date, filter?: ?string): Promise<Array<TCalendarItem>>;
   /**
+   * Calendar.remindersBetween()
    * Returns all reminders between the `startDate` and `endDate`. Use `filter` to search for specific reminders (keyword in the title).
    * This function fetches reminders asynchronously, so use async/await.
    * Note: Available from v3.0.25
@@ -1233,6 +1286,7 @@ declare class Calendar {
    */
   static remindersBetween(startDate: Date, endDate: Date, filter?: ?string): Promise<Array<TCalendarItem>>;
   /**
+   * Calendar.eventsToday()
    * Returns all events for today. Use `filter` to search for specific events (keyword in the title).
    * This function fetches events asynchronously, so use async/await.
    * Note: Available from v3.0.25
@@ -1241,6 +1295,7 @@ declare class Calendar {
    */
   static eventsToday(filter: ?string): Promise<Array<TCalendarItem>>;
   /**
+   * Calendar.remindersToday()
    * Returns all reminders between for today. Use `filter` to search for specific reminders (keyword in the title).
    * This function fetches reminders asynchronously, so use async/await.
    * Note: Available from v3.0.25
@@ -1249,6 +1304,7 @@ declare class Calendar {
    */
   static remindersToday(filter: ?string): Promise<Array<TCalendarItem>>;
   /**
+   * Calendar.update()
    * Updates an event or reminder based on the given CalendarItem, which needs to have an ID.
    * A CalendarItem has an ID, when you have used `.add(...)` and saved the return value or when you query
    * the event using `eventsBetween(...)`, `remindersBetween(...)`, `eventByID(...)`, `reminderByID(...)`, etc.
@@ -1260,6 +1316,7 @@ declare class Calendar {
    */
   static update(calendarItem: TCalendarItem): Promise<void>;
   /**
+   * Calendar.remove()
    * Removes an event or reminder based on the given CalendarItem, which needs to have an ID.
    * A CalendarItem has an ID, when you have used `.add(...)` and saved the return value or when you query
    * the event using `eventsBetween(...)`, `remindersBetween(...)`, `eventByID(...)`, `reminderByID(...)`, etc.
@@ -1271,6 +1328,7 @@ declare class Calendar {
    */
   static remove(calendarItem: TCalendarItem): Promise<void>;
   /**
+   * Calendar.eventByID()
    * Returns the event by the given ID. You can get the ID from a CalendarItem, which you got from using `.add(...)` (the return value is a CalendarItem with ID) or when you query the event using `eventsBetween(...)`, `eventByID(...)`, etc.
    * This function fetches reminders asynchronously, so use async/await.
    * Note: Available from v3.0.26
@@ -1279,6 +1337,7 @@ declare class Calendar {
    */
   static eventByID(id: string): Promise<TCalendarItem>;
   /**
+   * Calendar.reminderByID()
    * Returns the reminder by the given ID. You can get the ID from a CalendarItem, which you got from using `.add(...)` (the return value is a CalendarItem with ID) or when you query the event using `remindersBetween(...)`, `reminderByID(...)`, etc.
    * Use with async/await.
    * Note: Available from v3.0.26
@@ -1287,6 +1346,7 @@ declare class Calendar {
    */
   static reminderByID(id: string): Promise<TCalendarItem>;
   /**
+   * Calendar.remindersByLists()
    * Returns all reminders (completed and incomplete) for the given lists (array of strings).
    * If you keep the lists variable empty, NotePlan will return all reminders from all lists. You can get all Reminders lists calling `Calendar.availableReminderListTitles()`
    * This function fetches reminders asynchronously, so use async/await.
@@ -1296,6 +1356,7 @@ declare class Calendar {
    */
   static remindersByLists(lists: $ReadOnlyArray<string>): Promise<Array<TCalendarItem>>;
   /**
+   * Calendar.weekNumber()
    * Returns the week number of the given date adjusted by the start of the week configured by the user in the preferences.
    * @param {Date}
    * @returns {number} week number (integer)
@@ -1303,6 +1364,7 @@ declare class Calendar {
    */
   static weekNumber(date: Date): number;
   /**
+   * Calendar.startOfWeek()
    * Returns the first day of the given date's week adjusted by the start of the week configured by the user in the preferences (means the returned date will always be the configured first day of the week).
    * @param {Date} date
    * @returns {Date} date of start of week
@@ -1310,6 +1372,7 @@ declare class Calendar {
    */
   static startOfWeek(date: Date): Date;
   /**
+   * Calendar.endOfWeek()
    * Returns the last day of the given date's week adjusted by the start of the week configured by the user in the preferences (means the returned endOfWeek date will always be the day before the first day of the week specified in Preferences).
    * @param {Date} date
    * @returns {Date} date of last day of week
@@ -1418,7 +1481,7 @@ declare interface Paragraph {
    * WARNING: appears to be unreliable on iOS.
    * @return {$ReadOnlyArray<TParagraph> | void}
    */
-children(): $ReadOnlyArray < TParagraph > | void;
+  children(): $ReadOnlyArray<TParagraph> | void;
   /**
    * Returns an array of all paragraphs having the same blockID (including this paragraph). You can use `paragraph[0].note` to access the note behind it and make updates via `paragraph[0].note.updateParagraph(paragraph[0])` if you make changes to the content, type, etc (like checking it off as type = "done")
    * Note: Available from v3.5.2
@@ -1496,6 +1559,7 @@ declare interface TRange {
    */
   +length: number;
   /**
+   * Range.create()
    * Create an instance of a Range object with the start and end positions.
    * The length variable is calculated automatically and doesn't have to be set.
    * Example: Range.create(0, 10)
@@ -1617,6 +1681,7 @@ declare interface TCalendarItem {
    */
   +isRecurring: boolean;
   /**
+   * CalendarItem.create()
    * Create a CalendarItem. The .endDate is optional, but recommended for events.
    * Reminders don't use this field.
    *
@@ -1641,6 +1706,7 @@ declare interface TCalendarItem {
     availability?: number,
   ): TCalendarItem;
   /**
+   * CalendarItem.findLinkedFilenames()
    * Searches and returns all filenames it's linked to (meeting notes). Use with await. Returns an array of filenames.
    * @returns {Array<string>} promise to filename list
    * Note: Available from 3.9.1 (build 1020)
@@ -1664,14 +1730,17 @@ declare class Clipboard {
    */
   static +types: $ReadOnlyArray<string>;
   /**
+   * Clipboard.setStringForType()
    * Set the text of the clipboard using a specific type.
    */
   static setStringForType(string: string, type: string): void;
   /**
+   * Clipboard.stringForType()
    * Get the text in the clipboard accessing a specific type.
    */
   static stringForType(type: string): ?string;
   /**
+   * Clipboard.setBase64DataStringForType()
    * Set the data as base64 string for a specific type like an image or RTF.
    * Note: Available from v3.4.1
    * @param {string} base64String
@@ -1679,6 +1748,7 @@ declare class Clipboard {
    */
   static setBase64DataStringForType(base64String: string, type: string): void;
   /**
+   * Clipboard.base64DataStringForType()
    * Get the base64 data string for a specific type like an image or RTF from the clipboard.
    * Note: Available from v3.4.1
    * @param {string} type
@@ -1686,18 +1756,22 @@ declare class Clipboard {
    */
   static base64DataStringForType(type: string): string;
   /**
+   * Clipboard.dataForType()
    * Get the data in the clipboard accessing a specific type.
    */
   static dataForType(type: string): mixed;
   /**
+   * Clipboard.setDataForType()
    * Set the data in the clipboard for a specific type.
    */
   static setDataForType(data: mixed, type: string): void;
   /**
+   * Clipboard.clearContents()
    * Clears the contents of the clipboard.
    */
   static clearContents(): void;
   /**
+   * Clipboard.availableType()
    * Pass in the types you are interested in and get the available type back.
    */
   static availableType(fromTypes: $ReadOnlyArray<string>): ?string;
@@ -1766,15 +1840,15 @@ declare interface CoreNoteFields {
    * Folder + Filename of the note (the path is relative to the root of the chosen storage location)
    * From v3.6.0 can also *set* the filename, which does a rename.
    */
-filename: string;  /* Idea: TRegularFilename | TCalendarFilename; */
+  filename: string /* Idea: TRegularFilename | TCalendarFilename; */;
   /**
-  * Returns the relative, resolved path of the note (including the folder, like `folder/filename.txt`).
-  * If it's a teamspace note, it replaces the IDs in the path with the name of the teamspace and the name of the note. Teamspace note filenames end otherwise with an ID, and the teamspace is also represented as an ID.
-  * Note: Don't use this filename to read or write the note. Use `.filename`, instead.
-  * { getter only}.
-  * Note: Available from v3.17.0
-  */
-+resolvedFilename: string;
+   * Returns the relative, resolved path of the note (including the folder, like `folder/filename.txt`).
+   * If it's a teamspace note, it replaces the IDs in the path with the name of the teamspace and the name of the note. Teamspace note filenames end otherwise with an ID, and the teamspace is also represented as an ID.
+   * Note: Don't use this filename to read or write the note. Use `.filename`, instead.
+   * { getter only}.
+   * Note: Available from v3.17.0
+   */
+  +resolvedFilename: string;
   /**
    * Optional date if it's a calendar note
    * WARNING: As of 3.18.2 b1428 this is not available in Editor.
@@ -1809,7 +1883,7 @@ filename: string;  /* Idea: TRegularFilename | TCalendarFilename; */
    */
   content: string | void;
   /**
-   * Get or set the array of paragraphs contained in this note, such as tasks, bullets, etc. 
+   * Get or set the array of paragraphs contained in this note, such as tasks, bullets, etc.
    * If you set the paragraphs, the content of the note will be updated.
    * WARNING: From ~v3.16.3, Editor.paragraphs and Editor.note.paragraphs can be different, with Editor.paragraphs not including the frontmatter lines.
    */
@@ -1846,31 +1920,31 @@ filename: string;  /* Idea: TRegularFilename | TCalendarFilename; */
    * You can set types of a note by adding frontmatter e.g. `type: meeting-note, empty-note` (comma separated).
    * Note: Available on Note from v3.5.0, but only on Editor from v3.16.3.
    */
-+frontmatterTypes: $ReadOnlyArray < string >;
+  +frontmatterTypes: $ReadOnlyArray<string>;
   /**
-  * Returns the frontmatter key-value pairs inside the note. To set a frontmatter attribute, use setFrontmatterAttribute.
-  * You can also use the setter, but you will need to first read the complete frontmatter object (key-value pairs), change it and then set it. Otherwise the setter *won't* be triggered if you set it directly like `frontmatterAttributes["key"] = "value"`. This is more useful if you want to set multiple frontmatter values.
-  * Note: @dbwertheimer says "Returns {} if no frontmatter stripes or if there are stripes but no attributes."
-  * @returns {{[key: string]: string}}
-  * Note: Available on Note from 3.5.0, but only on Editor from v3.16.3.
-  * WARNING: The setter only works with macOS >= 14 and iOS >= 16, since below these versions, the frontmatter editor is not supported and the raw frontmatter is shown (if a user still calls this, a warning is logged).
-  */
-+frontmatterAttributes: Object;
-/**
- * Updates multiple frontmatter attributes at once in a single operation.
- * More efficient than calling setFrontmatterAttribute multiple times as it only reads and writes the note content once.
- * Each attribute object should have "key" and "value" properties.
- * Note: Available from v3.18.1 (build 1419)
- * @param {Array<{key: string, value: string}>} attributes - Array of key-value pairs to update
- * @example
- * note.updateFrontmatterAttributes([
- *   { key: "title", value: "My Title" },
- *   { key: "type", value: "project" },
- *   { key: "status", value: "draft" }
- * ])
- * Available from v3.18.1 (build 1419)
- */
-updateFrontmatterAttributes(attributes: Array<{key: string, value: string}>): void;
+   * Returns the frontmatter key-value pairs inside the note. To set a frontmatter attribute, use setFrontmatterAttribute.
+   * You can also use the setter, but you will need to first read the complete frontmatter object (key-value pairs), change it and then set it. Otherwise the setter *won't* be triggered if you set it directly like `frontmatterAttributes["key"] = "value"`. This is more useful if you want to set multiple frontmatter values.
+   * Note: @dbwertheimer says "Returns {} if no frontmatter stripes or if there are stripes but no attributes."
+   * @returns {{[key: string]: string}}
+   * Note: Available on Note from 3.5.0, but only on Editor from v3.16.3.
+   * WARNING: The setter only works with macOS >= 14 and iOS >= 16, since below these versions, the frontmatter editor is not supported and the raw frontmatter is shown (if a user still calls this, a warning is logged).
+   */
+  +frontmatterAttributes: Object;
+  /**
+   * Updates multiple frontmatter attributes at once in a single operation.
+   * More efficient than calling setFrontmatterAttribute multiple times as it only reads and writes the note content once.
+   * Each attribute object should have "key" and "value" properties.
+   * Note: Available from v3.18.1 (build 1419)
+   * @param {Array<{key: string, value: string}>} attributes - Array of key-value pairs to update
+   * @example
+   * note.updateFrontmatterAttributes([
+   *   { key: "title", value: "My Title" },
+   *   { key: "type", value: "project" },
+   *   { key: "status", value: "draft" }
+   * ])
+   * Available from v3.18.1 (build 1419)
+   */
+  updateFrontmatterAttributes(attributes: Array<{ key: string, value: string }>): void;
 
   /**
    * Renames the note. You can also define a folder path. The note will be moved to that folder and the folder will be automatically created.
@@ -2075,18 +2149,18 @@ updateFrontmatterAttributes(attributes: Array<{key: string, value: string}>): vo
    */
   replaceTextInCharacterRange(text: string, location: number, length: number): void;
 
-/**
-* Publishes the note using CloudKit (inserts a record on the public database). Build the web-link to the note by using the publicRecordID.
-* Note: Available from v3.9.1
-* @return {Promise}
-*/
-publish(): Promise < void>;
-/**
- * Unpublishes the note from CloudKit (deletes the database entry from the public database).
- * Note: Available from v3.9.1
- * @return {Promise}
- */
-unpublish(): Promise < void>;
+  /**
+   * Publishes the note using CloudKit (inserts a record on the public database). Build the web-link to the note by using the publicRecordID.
+   * Note: Available from v3.9.1
+   * @return {Promise}
+   */
+  publish(): Promise<void>;
+  /**
+   * Unpublishes the note from CloudKit (deletes the database entry from the public database).
+   * Note: Available from v3.9.1
+   * @return {Promise}
+   */
+  unpublish(): Promise<void>;
 
   /**
    * Generates a unique block ID and adds it to the content of this paragraph.
@@ -2121,26 +2195,26 @@ unpublish(): Promise < void>;
    * Resolves a conflict, if any, using the other version (which is version 2 in the conflict bar inside the UI). Once resolved you need to reload the note.
    * Note: Available from v3.9.3
    */
-resolveConflictWithOtherVersion(): void;
+  resolveConflictWithOtherVersion(): void;
 
-/**
- * To quickly identify if this specific note is from a teamspace.
- * Note: Available from v3.17.0
- * @returns {boolean}
- */
-+isTeamspaceNote: boolean;
-/**
- * The ID of the teamspace the note belongs to (will be undefined for private notes). This ID has the syntax of a UUID.
- * Note: Available from v3.17.0
- * @returns {?string}
- */
-+teamspaceID: ?string;
-/**
- * Returns the title of the teamspace the note belongs to (will be undefined for private notes)
- * Note: Available from v3.17.0
- * @returns {?string}
- */
-+teamspaceTitle: ?string;
+  /**
+   * To quickly identify if this specific note is from a teamspace.
+   * Note: Available from v3.17.0
+   * @returns {boolean}
+   */
+  +isTeamspaceNote: boolean;
+  /**
+   * The ID of the teamspace the note belongs to (will be undefined for private notes). This ID has the syntax of a UUID.
+   * Note: Available from v3.17.0
+   * @returns {?string}
+   */
+  +teamspaceID: ?string;
+  /**
+   * Returns the title of the teamspace the note belongs to (will be undefined for private notes)
+   * Note: Available from v3.17.0
+   * @returns {?string}
+   */
+  +teamspaceTitle: ?string;
 }
 
 declare class NotePlan {
@@ -2175,6 +2249,7 @@ declare class NotePlan {
    */
   static +environment: Object;
   /**
+   * NotePlan.ai()
    * This is an async function, use it with "await". Sends a prompt to OpenAI and returns the result.
    * Optionally send the content of notes as well to process by specifying them in the list 'filenames', which is an array. For example ["note1.md", "folder/note2.md"]. This needs to be the exact path to the note. Your note extension might differ, the default is .txt, if you haven't changed it.
    * For calendar notes, you can use YYYYMMDD.md, like 20241101.md, or 2024-W10.md for weeks, etc. Natural language input is also supported like "this week", "today", "tomorrow", "this month", "next year", etc.
@@ -2194,36 +2269,40 @@ declare class NotePlan {
    * @param {string} model (available from v3.16.3)
    * @returns {Promise<string>}
    */
-  static ai(prompt: string, filenames: Array < string >, useStrictFilenames: boolean, model ?: string): Promise < string >;
+  static ai(prompt: string, filenames: Array<string>, useStrictFilenames: boolean, model?: string): Promise<string>;
   /**
    * The selected sidebar folder (useful when a note is not showing in Editor, which is then null)
    * Note: available from v3.5.1
    */
   static +selectedSidebarFolder?: string;
   /**
+   * NotePlan.showConfigurationView()
    * Open the current plugin's config UI, if available.
    * Note: available from v3.3.2 (just for macOS so far)
    */
   static showConfigurationView(): Promise<void>;
   /**
+   * NotePlan.resetCaches()
    * To reset the caches, particularly in the case where the sidebar turns out incorrect.
    * It's an async operation, but it doesn't return a promise to tell you when it's done.
    * Note: available from v3.5.0
    */
   static resetCaches(): void;
   /**
+   * NotePlan.openURL()
    * Opens the given URL using the default browser (x-callback-urls can also be triggered with this).
    * Note: Available from v3.5.2
    */
   static openURL(url: string): void;
   /**
+   * NotePlan.stringDiff()
    * Returns the ranges that have changed between the two versions.
    * Note: Available from v3.7.2
    * @param {string} version1
    * @param {string} version2
    * @returns {Array<TRange>}
    */
-  static stringDiff(version1: string, version2: string): Array < TRange >;
+  static stringDiff(version1: string, version2: string): Array<TRange>;
   /**
    * Returns a list of all opened editors (in the main view, in split views and in floating windows). See more details in the "Editor" documentation.
    * Note: Available from v3.8.1 build 973
@@ -2237,6 +2316,7 @@ declare class NotePlan {
    */
   static +htmlWindows: Array<HTMLView>;
   /**
+   * NotePlan.ai()
    * Note: Available from v3.15.1 (macOS build 1300)
    * This is an async function, use it with "await". Sends a prompt to OpenAI and returns the result.
    * Optionally send the content of notes as well to process by specifying them in the list 'filenames', which is an array. For example ["note1.md", "folder/note2.md"]. This needs to be the exact path to the note. Your note extension might differ, the default is .txt, if you haven't changed it.
@@ -2253,6 +2333,7 @@ declare class HTMLView {
   // Impossible constructor.
   constructor(_: empty): empty;
   /**
+   * HTMLView.showSheet()
    * Show HTML in a sheet (e.g. mobile/iPad modal).
    * Note: Available from v3.6.2
    * @param {string} HTML to show
@@ -2261,6 +2342,7 @@ declare class HTMLView {
    */
   static showSheet(HTML: string, width?: number, height?: number): void;
   /**
+   * HTMLView.showWindow()
    * Open a non-modal window above the main window with the given html code and window title.
    * Note: Available from v3.7.0 (build >862)
    * Note: Following available from v3.9.1 (build 1020):
@@ -2275,6 +2357,7 @@ declare class HTMLView {
    */
   static showWindow(html: string, title: string, width?: number, height?: number, shouldFocus?: boolean): Window;
   /**
+   * HTMLView.showWindowWithOptions()
    * Open a non-modal window above the main window with the given html code and window title.
    * It returns a promise with the created window object.
    * Optionally, supply an object as the 3rd parameter to set window options: { width, height, x, y, shouldFocus, id }
@@ -2322,6 +2405,7 @@ declare class HTMLView {
    */
   close(): void;
   /**
+   * HTMLView.runJavaScript()
    * After opening an HTML window, make changes to the contents of the window by running JS code directly inside the opened window.
    * Returns a promise you can wait for with the return value, if any (depends if you added one to the JS code that is supposed to be executed).
    * Note: Available in v3.8. Second parameter added in build 1089.
@@ -2329,7 +2413,7 @@ declare class HTMLView {
    * @param { string | undefined } windowId ID of the HTML window to execute it in (undefined for non-desktop platforms)
    * @return { Promise | void }
    */
-  static runJavaScript(code: string, windowId: string | void): Promise < void>;
+  static runJavaScript(code: string, windowId: string | void): Promise<void>;
   /**
    * Set / get the position and size of an HTMLView window. Returns an object with x, y, width, height values.
    * If you want to change the coordinates or size, save the rect in a variable, modify the variable, then assign it to windowRect.


### PR DESCRIPTION
@jgclark I often search for commands in NotePlan.js but when I find them don't know if the command is under NotePlan or DataStore or what high-level object. I also find it sometimes hard to read which comment applies to which command. So I asked Cursor to add the full object.command to the JSDOC so that it is immediately obvious when you find one. It's purely optics change, but wanted you to be ok with it since you own this doc. Pls feel free to merge or reject.