### PR TITLE
Add includedCalendarSections filter to filter tasks by calendar section headings

### DIFF
--- a/jgclark.Dashboard/src/dashboardSettings.js
+++ b/jgclark.Dashboard/src/dashboardSettings.js
@@ -108,7 +108,7 @@ export const dashboardSettingDefs: Array<TSettingItem> = [
     key: 'includedCalendarSections',
     label: 'Calendar note Sections to Include',
     description:
-      "Comma-separated list of calendar note section headings to include when selecting open tasks/checklists to show. The matches are partial, so 'Home' will include 'Home' and 'The Home Areas' etc. If left blank, all sections are included.",
+      "Comma-separated list of calendar note section headings to include when selecting open tasks/checklists to show. This applies to all headings in the H4->H2 hierarchy for each line. The matches are partial, so 'Home' will include 'Home' and 'The Home Areas' etc. If left blank, all items for this section are included.",
     type: 'input',
     default: '',
     compactDisplay: true,

--- a/jgclark.Dashboard/src/dataGeneration.js
+++ b/jgclark.Dashboard/src/dataGeneration.js
@@ -10,6 +10,7 @@ import type { TDashboardSettings, TParagraphForDashboard, TSectionCode, TSection
 import { allSectionCodes } from './constants.js'
 import { getNumCompletedTasksFromNote } from './countDoneTasks'
 import {
+  appendCalendarSectionsFilterToDescription,
   createSectionOpenItemsFromParas,
   getDashboardSettings,
   getListOfEnabledSections,
@@ -252,7 +253,7 @@ export function getThisMonthSectionData(config: TDashboardSettings, useDemoData:
     }
     const nextPeriodNote = DataStore.calendarNoteByDate(new moment().add(1, 'month').toDate(), 'month')
     const nextPeriodFilename = nextPeriodNote?.filename ?? '(error)'
-    const doneCountData = getNumCompletedTasksFromNote(thisFilename)
+    const doneCountData = getNumCompletedTasksFromNote(thisFilename, true, true, config)
 
     // Set up formFields for the 'add buttons' (applied in Section.jsx)
     const formFieldsBase: Array<TSettingItem> = [{ type: 'input', label: 'Task:', key: 'text', focus: true }]
@@ -294,6 +295,7 @@ export function getThisMonthSectionData(config: TDashboardSettings, useDemoData:
     )
 
     let sectionDescription = `{closedOrOpenTaskCount} from ${dateStr}`
+    sectionDescription = appendCalendarSectionsFilterToDescription(sectionDescription, config)
     if (config?.FFlag_ShowSectionTimings) sectionDescription += ` [${timer(startTime)}]`
 
     const section: TSection = {
@@ -446,7 +448,7 @@ export function getThisQuarterSectionData(config: TDashboardSettings, useDemoDat
     }
     const nextPeriodNote = DataStore.calendarNoteByDate(new moment().add(1, 'quarter').toDate(), 'quarter')
     const nextPeriodFilename = nextPeriodNote?.filename ?? ''
-    const doneCountData = getNumCompletedTasksFromNote(thisFilename)
+    const doneCountData = getNumCompletedTasksFromNote(thisFilename, true, true, config)
 
     // Set up formFields for the 'add buttons' (applied in Section.jsx)
     const formFieldsBase: Array<TSettingItem> = [{ type: 'input', label: 'Task:', key: 'text', focus: true }]
@@ -488,6 +490,7 @@ export function getThisQuarterSectionData(config: TDashboardSettings, useDemoDat
     )
 
     let sectionDescription = `{countWithLimit} from ${dateStr}`
+    sectionDescription = appendCalendarSectionsFilterToDescription(sectionDescription, config)
     if (config?.FFlag_ShowSectionTimings) sectionDescription += ` [${timer(startTime)}]`
 
     const section: TSection = {
@@ -634,7 +637,7 @@ export function getThisYearSectionData(config: TDashboardSettings, useDemoData: 
     }
     const nextPeriodNote = DataStore.calendarNoteByDate(new moment().add(1, 'year').toDate(), 'year')
     const nextPeriodFilename = nextPeriodNote?.filename ?? ''
-    const doneCountData = getNumCompletedTasksFromNote(thisFilename)
+    const doneCountData = getNumCompletedTasksFromNote(thisFilename, true, true, config)
 
     // Set up formFields for the 'add buttons' (applied in Section.jsx)
     const formFieldsBase: Array<TSettingItem> = [{ type: 'input', label: 'Task:', key: 'text', focus: true }]
@@ -676,6 +679,7 @@ export function getThisYearSectionData(config: TDashboardSettings, useDemoData: 
     )
 
     let sectionDescription = `{countWithLimit} from ${dateStr}`
+    sectionDescription = appendCalendarSectionsFilterToDescription(sectionDescription, config)
     if (config?.FFlag_ShowSectionTimings) sectionDescription += ` [${timer(startTime)}]`
 
     const section: TSection = {

--- a/jgclark.Dashboard/src/dataGenerationDays.js
+++ b/jgclark.Dashboard/src/dataGenerationDays.js
@@ -9,6 +9,7 @@ import pluginJson from '../plugin.json'
 import type { TDashboardSettings, TParagraphForDashboard, TSection, TSectionItem, TSettingItem } from './types'
 import { getDoneCountsForToday, getNumCompletedTasksFromNote } from './countDoneTasks'
 import {
+  appendCalendarSectionsFilterToDescription,
   createSectionItemObject,
   createSectionOpenItemsFromParas,
   getNotePlanSettings,
@@ -169,6 +170,7 @@ export function getTodaySectionData(config: TDashboardSettings, useDemoData: boo
     )
 
     let sectionDescription = `{closedOrOpenTaskCount} from ${todayDateLocale}`
+    sectionDescription = appendCalendarSectionsFilterToDescription(sectionDescription, config)
     if (config?.FFlag_ShowSectionTimings) sectionDescription += ` [${timer(startTime)}]`
 
     const section: TSection = {
@@ -451,8 +453,9 @@ export function getYesterdaySectionData(config: TDashboardSettings, useDemoData:
       }
     }
     // Note: this only counts from yesterday's note
-    const doneCountData = getNumCompletedTasksFromNote(thisFilename)
+    const doneCountData = getNumCompletedTasksFromNote(thisFilename, true, true, config)
     let sectionDescription = `{closedOrOpenTaskCount} from ${yesterdayDateLocale}`
+    sectionDescription = appendCalendarSectionsFilterToDescription(sectionDescription, config)
     if (config?.FFlag_ShowSectionTimings) sectionDescription += ` [${timer(startTime)}]`
 
     const section: TSection = {
@@ -607,6 +610,7 @@ export function getTomorrowSectionData(config: TDashboardSettings, useDemoData: 
     )
 
     let sectionDescription = `{count} from ${tomorrowDateLocale}`
+    sectionDescription = appendCalendarSectionsFilterToDescription(sectionDescription, config)
     if (config?.FFlag_ShowSectionTimings) sectionDescription += ` [${timer(startTime)}]`
 
     const section: TSection = {

--- a/jgclark.Dashboard/src/dataGenerationOverdue.js
+++ b/jgclark.Dashboard/src/dataGenerationOverdue.js
@@ -6,7 +6,7 @@
 
 import moment from 'moment/min/moment-with-locales'
 import pluginJson from '../plugin.json'
-import { createSectionItemObject, filterParasByRelevantFolders, filterParasByIgnoreTerms, filterParasByCalendarHeadingSections, filterParasByAllowedTeamspaces, makeDashboardParas, getNotePlanSettings } from './dashboardHelpers'
+import { createSectionItemObject, filterParasByRelevantFolders, filterParasByIgnoreTerms, filterParasByCalendarHeadingSections, filterParasByIncludedCalendarSections, filterParasByAllowedTeamspaces, makeDashboardParas, getNotePlanSettings, appendCalendarSectionsFilterToDescription } from './dashboardHelpers'
 import { openYesterdayParas, refYesterdayParas } from './demoData'
 import type { TDashboardSettings, TParagraphForDashboard, TSection, TSectionItem } from './types'
 import { clo, clof, JSP, logDebug, logError, logInfo, logTimer, logWarn, timer } from '@helpers/dev'
@@ -137,6 +137,7 @@ export async function getOverdueSectionData(config: TDashboardSettings, useDemoD
       sectionDescription += ` from last ${String(config.lookBackDaysForOverdue)} days`
     }
     if (overdueParas.length > 0) sectionDescription += ` ordered by ${config.overdueSortOrder}`
+    sectionDescription = appendCalendarSectionsFilterToDescription(sectionDescription, config)
     if (config?.FFlag_ShowSectionTimings) sectionDescription += ` [${timer(thisStartTime)}]`
 
     // If we have more than the limit, then we need to show the total count as an extra information message
@@ -219,6 +220,9 @@ export async function getRelevantOverdueTasks(
 
     // Filter out anything from 'ignoreItemsWithTerms' setting
     filteredOverdueParas = filterParasByIgnoreTerms(filteredOverdueParas, dashboardSettings, thisStartTime, 'getRelevantOverdueTasks')
+
+    // Filter out anything not matching 'includedCalendarSections' setting, if set
+    filteredOverdueParas = filterParasByIncludedCalendarSections(filteredOverdueParas, dashboardSettings, thisStartTime, 'getRelevantOverdueTasks')
 
     // Also if wanted, apply to calendar headings in this note
     filteredOverdueParas = filterParasByCalendarHeadingSections(filteredOverdueParas, dashboardSettings, thisStartTime, 'getRelevantOverdueTasks')

--- a/jgclark.Dashboard/src/dataGenerationWeeks.js
+++ b/jgclark.Dashboard/src/dataGenerationWeeks.js
@@ -9,6 +9,7 @@ import pluginJson from '../plugin.json'
 import type { TDashboardSettings, TParagraphForDashboard, TSection, TSectionItem, TSettingItem } from './types'
 import { getNumCompletedTasksFromNote } from './countDoneTasks'
 import {
+  appendCalendarSectionsFilterToDescription,
   createSectionOpenItemsFromParas,
   getNotePlanSettings,
   getOpenItemParasForTimePeriod,
@@ -73,7 +74,7 @@ export function getThisWeekSectionData(config: TDashboardSettings, useDemoData: 
     }
     const nextPeriodNote = DataStore.calendarNoteByDate(new moment().add(1, 'week').toDate(), 'week')
     const nextPeriodFilename = nextPeriodNote?.filename ?? '(error)'
-    const doneCountData = getNumCompletedTasksFromNote(thisFilename)
+    const doneCountData = getNumCompletedTasksFromNote(thisFilename, true, true, config)
 
     // Set up formFields for the 'add buttons' (applied in Section.jsx)
     const formFieldsBase: Array<TSettingItem> = [{ type: 'input', label: 'Task:', key: 'text', focus: true }]
@@ -115,6 +116,7 @@ export function getThisWeekSectionData(config: TDashboardSettings, useDemoData: 
         : [],
     )
     let sectionDescription = `{countWithLimit} {itemType} from ${dateStr}`
+    sectionDescription = appendCalendarSectionsFilterToDescription(sectionDescription, config)
     if (config?.FFlag_ShowSectionTimings) sectionDescription += ` [${timer(startTime)}]`
 
     const section: TSection = {
@@ -274,8 +276,9 @@ export function getLastWeekSectionData(config: TDashboardSettings, useDemoData: 
       }
     }
 
-    const doneCountData = getNumCompletedTasksFromNote(thisFilename)
+    const doneCountData = getNumCompletedTasksFromNote(thisFilename, true, true, config)
     let sectionDescription = `{countWithLimit} {itemType} from ${dateStr}`
+    sectionDescription = appendCalendarSectionsFilterToDescription(sectionDescription, config)
     if (config?.FFlag_ShowSectionTimings) sectionDescription += ` [${timer(startTime)}]`
 
     const section: TSection = {

--- a/jgclark.Dashboard/src/types.js
+++ b/jgclark.Dashboard/src/types.js
@@ -81,6 +81,7 @@ export type TDashboardSettings = {
   ignoreItemsWithTerms: string, // Note: Run through stringListOrArrayToArray() before use
   includedTeamspaces: Array<string>, // Array of teamspace IDs to include ('private' for Private space)
   includedFolders: string, // Note: Run through stringListOrArrayToArray() before use
+  includedCalendarSections?: string, // Comma-separated string of calendar section headings (H2/H3/H4) to include. Note: Run through stringListOrArrayToArray() before use
   showFolderName: boolean, // Note: was includeFolderName before 2.2.0.
   showScheduledDates: boolean, // Note: was includeScheduledDates before 2.2.0.rename to show...
   showTaskContext: boolean, // Note: was includeTaskContext before 2.2.0.


### PR DESCRIPTION
This PR finalizes @jgclark support for filtering tasks by calendar section headings using the `includedCalendarSections` setting.

## Changes

- Add `includedCalendarSections` setting (CSV string) to filter calendar note tasks by section headings
- Implement `filterParasByIncludedCalendarSections` function with partial, case-insensitive matching
- Apply filter to all time period sections (today, yesterday, tomorrow, week, month, quarter, year)
- Apply filter to overdue section
- Apply filter to referenced paragraphs
- Update done counts to respect `includedCalendarSections` filter
- Add section description helper to show filter status (e.g., 'showing Medawar only')
- Update Flow types to include `includedCalendarSections` as optional string

## Testing

The filter uses partial, case-insensitive matching, so "Medawar" will match headings like "Medawar Tasks" or "The Medawar Section". When the filter is active, section descriptions will show "(showing Medawar only)" to indicate the filter is applied.