### PR TITLE
Calendar plugin: support event colors stored in event notes

### DIFF
--- a/emetzger.Calendar/script.js
+++ b/emetzger.Calendar/script.js
@@ -2178,6 +2178,16 @@ function getCalendarHTML() {
     }
 
     function getEventColor(event) {
+      // support for event color coding in Calendars by Readdle and Calendar 366 applications
+      if (event.notes) {
+        const hexMatch = event.notes.match(/@colorHex:(#[0-9A-Fa-f]{6})|\\[!([0-9A-Fa-f]{6})!\\]/);
+        if (hexMatch) {
+          const color = hexMatch[1] || hexMatch[2];
+          const finalColor = color.startsWith('#') ? color : '#' + color;
+          return finalColor;
+        }
+      }
+      // event (calendar) color and fallback color
       return event.color || '#5856D6';
     }
 


### PR DESCRIPTION
Enable support for custom event colors saved within notes, providing compatibility with 'Calendars by Readdle' and 'Calendar 366' apps.

### Description
This PR adds support for parsing event colors stored inside the event notes. This behavior is used by some third-party calendar applications like 'Calendars by Readdle' and 'Calendar 366' to persist custom colors.

### Motivation
Users of these alternative calendar apps currently lose their color-coding when events are displayed in the Calendar plugin. This change improves ecosystem compatibility for those users.

### Risk Assessment & Implementation
While this addresses a non-standard feature specific to certain apps, the implementation is very straightforward and isolated:
- It safely falls back to default behavior if no color data is found in the note.
- It introduces no breaking changes or performance overhead for standard events.
