### PR TITLE
fix: upgrade cipher-base to 1.0.5 (CVE-2025-9287)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "bump-regex": "4.1.0",
         "chroma-js": "^3.1.2",
         "chrono-node": "^2.7.7",
+        "cipher-base": "^1.0.5",
         "clipboardy": "3.0.0",
         "columnify": "^1.6.0",
         "commander": "^8.1.0",
@@ -9125,13 +9126,16 @@
       }
     },
     "node_modules/cipher-base": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.5.tgz",
+      "integrity": "sha512-xq7ICKB4TMHUx7Tz1L9O2SGKOhYMOTR32oir45Bq28/AQTpHogKgHcoYFSdRbMtddl+ozNXfXY9jWcgYKmde0w==",
       "license": "MIT",
       "dependencies": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/cjs-module-lexer": {

--- a/package.json
+++ b/package.json
@@ -163,6 +163,7 @@
     "bump-regex": "4.1.0",
     "chroma-js": "^3.1.2",
     "chrono-node": "^2.7.7",
+    "cipher-base": "^1.0.5",
     "clipboardy": "3.0.0",
     "columnify": "^1.6.0",
     "commander": "^8.1.0",


### PR DESCRIPTION
## Summary
Upgrade cipher-base from 1.0.4 to 1.0.5 to fix CVE-2025-9287.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2025-9287 |
| **Severity** | CRITICAL |
| **Scanner** | trivy |
| **Rule** | `CVE-2025-9287` |
| **File** | `package-lock.json` |
| **Assessment** | Likely exploitable |

**Description**: cipher-base: Cipher-base hash manipulation

## Evidence

**Scanner confirmation**: trivy rule `CVE-2025-9287` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Changes
- `package.json`
- `package-lock.json`

## Behavior Preservation
The change is scoped to 2 files on the vulnerable path, and the project's existing tests still pass, so intended behavior is unchanged.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
