### PR TITLE
Remove 233 Flow suppressions that suppress nothing

### DIFF
--- a/dwertheimer.DateAutomations/src/dateFunctions.js
+++ b/dwertheimer.DateAutomations/src/dateFunctions.js
@@ -104,18 +104,15 @@ function getFormattedDateTime() {
           // conditionall add those keys to config
           if (ds !== '') {
             // Ignore type error for now
-            // $FlowFixMe
             config.dateStyle = ds
           }
           if (ts !== '') {
-            // $FlowFixMe
             config.timeStyle = ts
           }
           config.hour12 = h12
 
           const text = new Intl.DateTimeFormat(
             loc,
-            // $FlowFixMe
             config,
           ).format()
 
@@ -221,11 +218,8 @@ export async function getWeekDates(paramStr: string = ''): Promise<string> {
   const format = String(await getTagParamsFromString(paramStr, 'format', 'EEE yyyy-MM-dd'))
   // $FlowFixme complains about number literals even though I am checking them as numbers in arange
   if (weekStartsOn >= 0 && weekStartsOn <= 6) {
-    // $FlowIgnore
     console.log(dateFormat(new Date(startOfWeek(new Date(), { weekStartsOn: weekStartsOn })), 'yyyy-MM-dd'))
-    // $FlowIgnore
     const start = dateFormat(new Date(startOfWeek(new Date(), { weekStartsOn: weekStartsOn })), format)
-    // $FlowIgnore
     const end = dateFormat(new Date(endOfWeek(new Date(), { weekStartsOn: weekStartsOn })), format)
     return `${start} - ${end}`
   } else {

--- a/dwertheimer.EventAutomations/__tests__/NPTimeblocking.Integration.test.js
+++ b/dwertheimer.EventAutomations/__tests__/NPTimeblocking.Integration.test.js
@@ -211,7 +211,6 @@ describe('dwertheimer.EventAutomations' /* pluginID */, () => {
       // const spy = jest.spyOn(global.Editor, 'insertParagraph')
       await mainFile.insertTodosAsTimeblocks()
       // insertParagraph doesn't work properly because it happens in the mock
-      // $FlowIgnore - jest doesn't know about this param
       // expect(spy.mock.lastCall[1]).toEqual(`No todos/references marked for this day!`)
       // spy.mockRestore()
       DataStore.settings = oldSettings

--- a/dwertheimer.EventAutomations/__tests__/NPTimeblocking.test.js
+++ b/dwertheimer.EventAutomations/__tests__/NPTimeblocking.test.js
@@ -126,7 +126,6 @@ describe('dwertheimer.EventAutomations' /* pluginID */, () => {
         Editor.note.backlinks = []
         const spy = jest.spyOn(CommandBar, 'prompt')
         await mainFile.insertTodosAsTimeblocks()
-        // $FlowIgnore - jest doesn't know about this param
         expect(mockWasCalledWithString(spy, /No todos\/references marked for >today/)).toBe(true)
         spy.mockRestore()
       })

--- a/dwertheimer.EventAutomations/src/NPTimeblocking.js
+++ b/dwertheimer.EventAutomations/src/NPTimeblocking.js
@@ -110,7 +110,6 @@ async function getPopulatedTimeMapForToday(dateStr: string, intervalMins: number
   }
   const blankDayMap = getBlankDayMap(parseInt(intervalMins))
 
-  // $FlowFixMe - [prop-missing] and [incompatible-variance]
   const eventMap = blockOutEvents(eventsScheduledForToday, blankDayMap, config)
   return eventMap
 }
@@ -188,7 +187,6 @@ export async function DELETEMEcreateTimeBlocksForTodaysTasks(config: AutoTimeBlo
     if (openOrScheduledForToday) {
       const sortedTodos = openOrScheduledForToday.length ? sortListBy(openOrScheduledForToday, '-priority') : []
       logDebug(pluginJson, `After sortListBy, ${sortedTodos.length} open items  Editor.paras=${Editor.paragraphs.length}`)
-      // $FlowIgnore
       if (timeBlockTag?.length) {
         logDebug(pluginJson, `timeBlockTag: ("${timeBlockTag}"), Editor.paras=${Editor.paragraphs.length}`)
       } else {

--- a/dwertheimer.EventAutomations/src/events.js
+++ b/dwertheimer.EventAutomations/src/events.js
@@ -51,10 +51,8 @@ export async function createNoteForCalendarItem(useQuickTemplate: boolean = true
   // Override the quickTemplateNote title with the selected event
   // $FlowIgnore
   const selEvent = selections.find((event) => event.value === selectedEvent)
-  // $FlowIgnore
   // const theTime = selEvent.time === '00:00' ? '' : selEvent.time
   logDebug(pluginJson, `Selected event: ${selectedEvent} ${String(JSON.stringify(selEvent))}`)
-  // $FlowIgnore
   // const theTitle = `${selectedEvent} {{date8601()}} ${theTime || ''}`
   if (selectedEvent && useQuickTemplate) {
     // quickTemplateNote is not defined!

--- a/dwertheimer.EventAutomations/src/timeblocking-helpers.js
+++ b/dwertheimer.EventAutomations/src/timeblocking-helpers.js
@@ -260,9 +260,7 @@ export function createOpenBlockObject(block: BlockData, config: { [key: string]:
   if (!startTime || !endTime) return null
   return {
     start: getTimeStringFromDate(startTime),
-    // $FlowIgnore
     end: getTimeStringFromDate(endTime),
-    // $FlowIgnore
     minsAvailable: differenceInMinutes(endTime, startTime, { roundingMethod: 'ceil' }),
     title: block.title,
   }
@@ -449,13 +447,11 @@ export function ORIGINALprocessByTimeBlockTag(sortedTaskList: Array<ParagraphWit
   }
   namedBlocks.forEach((block) => {
     const blockTitle = (block.title || '').replace(config.timeblockTextMustContainString, '').replace(/ {2,}/g, ' ').trim()
-    //$FlowIgnore
     const tasksMatchingThisNamedTimeblock = unprocessedTasks.filter((task) => (block.title ? namedTagExistsInLine(blockTitle, task.content) : false))
     logDebug(`processByTimeBlockTag tasksMatchingThisNamedTimeblock (${blockTitle}): ${JSP(tasksMatchingThisNamedTimeblock.map((p) => p.content || ''))}`)
     tasksMatchingThisNamedTimeblock.forEach((task, i) => {
       // call matchTasksToSlots for each block as if the block all that's available
       // remove from sortedTaskList
-      // $FlowIgnore
       logDebug(pluginJson, `Calling matchTasksToSlots for item[${i}]: ${task.content} duration:${task.duration}`)
       // const filteredTimeMap = timeMap.filter((t) => t.start >= block.start && t.start <= block.end)
       // second `t.busy` cast: the first `.includes()` call invalidates Flow's `typeof t.busy === 'string'` refinement on the property
@@ -494,7 +490,6 @@ export function ORIGINALprocessByTimeBlockTag(sortedTaskList: Array<ParagraphWit
   newBlockList = blockList?.filter((b) => !b.title || b.title === '') || [] // remove the named blocks from the list
 
   config.mode = 'PRIORITY_FIRST' // now that we've processed the named blocks, we can process the rest of the tasks by priority
-  // $FlowIgnore
   results.push(matchTasksToSlots(unprocessedTasks, { blockList: newBlockList, timeMap }, config))
 
   return {
@@ -533,7 +528,6 @@ export function matchTasksToSlots(sortedTaskList: Array<ParagraphWithDuration>, 
       let scheduling = true
       let schedulingCount = 0
       let scheduledMins = 0
-      // $FlowIgnore - flow doesn't like .length below but it is safe
       for (let i = 0; i < newBlockList.length && scheduling; i++) {
         if (newBlockList && newBlockList[i]) {
           let block = newBlockList[i]
@@ -635,7 +629,6 @@ export const addDurationToTasks = (tasks: Array<SortableParagraphSubset>, config
 
 export function getTimeBlockTimesForEvents(timeMap: IntervalMap, todos: Array<SortableParagraphSubset>, config: { [key: string]: any }): TimeBlocksWithMap {
   let newInfo: TimeBlocksWithMap = { timeMap, blockList: [], timeBlockTextList: [], noTimeForTasks: {} }
-  // $FlowIgnore
   const availableTimes = filterTimeMapToOpenSlots(timeMap, config) // will be different for BY_TIMEBLOCK_TAG
   if (availableTimes.length === 0) {
     timeMap.forEach((m) => console.log(`getTimeBlockTimesForEvents no more times available: ${JSON.stringify(m)}`))

--- a/dwertheimer.EventAutomations/src/timeblocking-shared.js
+++ b/dwertheimer.EventAutomations/src/timeblocking-shared.js
@@ -92,7 +92,6 @@ export function getConfig(): AutoTimeBlockingConfig {
   const numKeys = Object.keys(config).length
   if (numKeys && !(numKeys === 1 && config._logLevel)) {
     try {
-      // $FlowIgnore
       // In real NotePlan, config.timeblockTextMustContainString won't be set, but in testing it will be, so this covers both test and prod
       if (!config.timeblockTextMustContainString) config.timeblockTextMustContainString = DataStore.preference('timeblockTextMustContainString') || ''
       validateAutoTimeBlockingConfig(config)
@@ -178,7 +177,6 @@ export async function writeSyncedCopies(todosParagraphs: Array<TParagraph>, conf
       return
     }
     logDebug(pluginJson, `Inserting synced list content: ${syncedList.length} items`)
-    // $FlowIgnore
     await insertItemsIntoNote(Editor, syncedList, config.syncedCopiesTitle, config.foldSyncedCopiesHeading, config)
   }
 }
@@ -191,7 +189,6 @@ export async function insertItemsIntoNote(
   config: AutoTimeBlockingConfig = getConfig(),
 ) {
   if (list && list.length > 0 && note) {
-    // $FlowIgnore
     logDebug(pluginJson, `insertItemsIntoNote: items.length=${list.length}`)
     clo(list, `insertItemsIntoNote: list`)
     clof(list, `insertItemsIntoNote: list`, null, false)

--- a/dwertheimer.Favorites/src/components/FavoritesView.jsx
+++ b/dwertheimer.Favorites/src/components/FavoritesView.jsx
@@ -379,13 +379,11 @@ function FavoritesViewComponent({
   // Note: __windowId is automatically injected by Root.jsx sendToPlugin, so we don't need to add it here
   const handleItemClick = useCallback(
     (item: FavoriteNote | FavoriteCommand | FolderHeaderItem, event: MouseEvent) => {
-      // $FlowFixMe[prop-missing] - header pseudo-items are not clickable
       if (item && item.__isFolderHeader) return
       const isOptionClick = event.altKey || (event.metaKey === false && event.ctrlKey) // Alt key (option on Mac)
       const isCmdClick = event.metaKey || event.ctrlKey // Cmd key (meta on Mac, ctrl on Windows)
 
       if (showNotes) {
-        // $FlowFixMe[incompatible-cast] - item is FavoriteNote when showNotes is true
         const note: FavoriteNote = (item: any)
         // Send action to plugin to open note
         dispatch(
@@ -401,7 +399,6 @@ function FavoritesViewComponent({
           'FavoritesView: openNote',
         )
       } else {
-        // $FlowFixMe[incompatible-cast] - item is FavoriteCommand when showNotes is false
         const command: FavoriteCommand = (item: any)
         // Send action to plugin to run command
         dispatch(
@@ -580,7 +577,6 @@ function FavoritesViewComponent({
         )
       }
 
-      // $FlowFixMe[incompatible-cast] - item is FavoriteNote when showNotes is true
       const note: FavoriteNote = item
       const folder = note.folder || ''
       const folderDisplay = folder && folder !== '/' ? `${folder} / ` : ''
@@ -621,7 +617,6 @@ function FavoritesViewComponent({
 
   // Render command item
   const renderCommandItem = useCallback((item: any, index: number): Node => {
-    // $FlowFixMe[incompatible-cast] - item is FavoriteCommand when showNotes is false
     const command: FavoriteCommand = item
     return (
       <div className="favorites-item-command">
@@ -637,7 +632,6 @@ function FavoritesViewComponent({
   // Filter function for notes
   const filterNote = useCallback((item: any, text: string): boolean => {
     if (!text) return true
-    // $FlowFixMe[incompatible-cast] - item is FavoriteNote when showNotes is true
     const note: FavoriteNote = item
     const searchText = text.toLowerCase()
     const title = (note.title || '').toLowerCase()
@@ -652,7 +646,6 @@ function FavoritesViewComponent({
   // Filter function for commands
   const filterCommand = useCallback((item: any, text: string): boolean => {
     if (!text) return true
-    // $FlowFixMe[incompatible-cast] - item is FavoriteCommand when showNotes is false
     const command: FavoriteCommand = item
     const searchText = text.toLowerCase()
     const name = (command.name || '').toLowerCase()
@@ -664,11 +657,9 @@ function FavoritesViewComponent({
   const getItemLabel = useCallback(
     (item: any): string => {
       if (showNotes) {
-        // $FlowFixMe[incompatible-cast] - item is FavoriteNote when showNotes is true
         const note: FavoriteNote = item
         return note.title || note.filename || ''
       } else {
-        // $FlowFixMe[incompatible-cast] - item is FavoriteCommand when showNotes is false
         const command: FavoriteCommand = item
         return command.name || ''
       }

--- a/dwertheimer.Forms/src/NPTemplateForm.js
+++ b/dwertheimer.Forms/src/NPTemplateForm.js
@@ -448,7 +448,6 @@ export async function openFormBuilder(templateTitle?: string): Promise<void> {
       // Ask user to choose or create a new template
       const createNew = await CommandBar.showOptions(['Create New Form', 'Edit Existing Form'], 'Form Builder', 'Choose an option')
       clo(createNew, `openFormBuilder: User selected option`)
-      // $FlowFixMe[incompatible-type] - showOptions returns number index
       if (createNew.value === 'Create New Form' || createNew.index === 0) {
         logDebug(pluginJson, `openFormBuilder: User chose to create new template`)
         // Create new template
@@ -650,7 +649,6 @@ export async function openFormBuilder(templateTitle?: string): Promise<void> {
             logWarn(pluginJson, `openFormBuilder: [STEP 6] WARNING - receivingTemplateTitle was set to "${receivingTemplateTitle}" but not found in reloaded note frontmatter!`)
           }
         }
-        // $FlowFixMe[incompatible-type] - showOptions returns number index
       } else if (createNew.index === 1 || createNew.value === 'Edit Existing Form') {
         logDebug(pluginJson, `openFormBuilder: User chose to edit existing form`)
 

--- a/dwertheimer.Forms/src/components/FormBrowserView.jsx
+++ b/dwertheimer.Forms/src/components/FormBrowserView.jsx
@@ -64,11 +64,8 @@ export function FormBrowserView({
   useEffect(() => {
     const handleResponse = (event: MessageEvent) => {
       const { data: eventData } = event
-      // $FlowFixMe[incompatible-type] - eventData can be various types
       if (eventData && typeof eventData === 'object' && eventData.type === 'RESPONSE' && eventData.payload) {
-        // $FlowFixMe[prop-missing] - payload structure is validated above
         const payload = eventData.payload
-        // $FlowFixMe[prop-missing] - payload structure is validated above
         if (payload && typeof payload === 'object') {
           const correlationId = (payload: any).correlationId
           const success = (payload: any).success

--- a/dwertheimer.Forms/src/components/FormBuilder.jsx
+++ b/dwertheimer.Forms/src/components/FormBuilder.jsx
@@ -195,7 +195,6 @@ You can edit or delete this comment field - it's just a note to help you get sta
     }
     try {
       // Use browser Clipboard API directly - no need for plugin round-trip
-      // $FlowFixMe[prop-missing] - navigator.clipboard may not be in Flow types
       if (navigator.clipboard && typeof (navigator.clipboard: any).writeText === 'function') {
         await (navigator.clipboard: any).writeText(urlToCopy)
         dispatch('SHOW_TOAST', {

--- a/dwertheimer.Forms/src/components/FormBuilderView.jsx
+++ b/dwertheimer.Forms/src/components/FormBuilderView.jsx
@@ -57,11 +57,8 @@ export function WebView({ data, dispatch, reactSettings, setReactSettings, onSub
   useEffect(() => {
     const handleResponse = (event: MessageEvent) => {
       const { data: eventData } = event
-      // $FlowFixMe[incompatible-type] - eventData can be various types
       if (eventData && typeof eventData === 'object' && eventData.type === 'RESPONSE' && eventData.payload) {
-        // $FlowFixMe[prop-missing] - payload structure is validated above
         const payload = eventData.payload
-        // $FlowFixMe[prop-missing] - payload structure is validated above
         if (payload && typeof payload === 'object') {
           const correlationId = (payload: any).correlationId
           const success = (payload: any).success

--- a/dwertheimer.Forms/src/components/FormView.jsx
+++ b/dwertheimer.Forms/src/components/FormView.jsx
@@ -382,7 +382,6 @@ export function FormView({ data, dispatch, reactSettings, setReactSettings, onSu
     const customCSS = pluginData?.customCSS || ''
     if (!customCSS || typeof document === 'undefined') return
 
-    // $FlowFixMe[incompatible-use] - document.head is checked for null
     const head = document.head
     if (!head) return
 
@@ -393,7 +392,6 @@ export function FormView({ data, dispatch, reactSettings, setReactSettings, onSu
     if (!styleElement) {
       styleElement = document.createElement('style')
       styleElement.id = styleId
-      // $FlowFixMe[incompatible-use] - head is checked for null above
       head.appendChild(styleElement)
     }
 
@@ -415,9 +413,7 @@ export function FormView({ data, dispatch, reactSettings, setReactSettings, onSu
     const handleResponse = (event: MessageEvent) => {
       const responseStartTime = performance.now()
       const { data: eventData } = event
-      // $FlowFixMe[incompatible-type] - eventData can be various types
       if (eventData && typeof eventData === 'object' && eventData.type === 'RESPONSE' && eventData.payload) {
-        // $FlowFixMe[prop-missing] - payload structure is validated above
         const payload = eventData.payload
         if (payload && typeof payload === 'object' && payload.correlationId && typeof payload.correlationId === 'string') {
           const { correlationId, success } = payload

--- a/dwertheimer.Forms/src/formBrowserHandlers.js
+++ b/dwertheimer.Forms/src/formBrowserHandlers.js
@@ -214,7 +214,6 @@ export async function getFormFields(params: { templateFilename?: string, templat
         
         // Send banner message to React window if windowId is provided
         if (params.windowId && typeof params.windowId === 'string' && params.windowId.length > 0) {
-          // $FlowFixMe[incompatible-call] - We've checked that windowId is a string above
           await sendBannerMessage(params.windowId, warningMsg, 'WARN', 10000)
         }
       }

--- a/dwertheimer.Forms/src/formSubmitHandlers.js
+++ b/dwertheimer.Forms/src/formSubmitHandlers.js
@@ -341,7 +341,6 @@ export async function handleFormSubmitAction(data: any, reactWindowData: any, wi
     // Update window data with error/aiAnalysisResult if present
     // Only send SET_DATA if there's an error or AI analysis result to display
     if (hasAiAnalysis || hasFormSubmissionError) {
-      // $FlowFixMe[exponential-spread] - Building object step by step to avoid Flow exponential spread issue
       const updatedPluginData: any = {}
       const basePluginData = reactWindowData.pluginData || {}
       Object.keys(basePluginData).forEach((key) => {

--- a/dwertheimer.ReactSkeleton/src/react/components/WebView.jsx
+++ b/dwertheimer.ReactSkeleton/src/react/components/WebView.jsx
@@ -155,11 +155,8 @@ export function WebView({ data, dispatch, reactSettings, setReactSettings }: Pro
   useEffect(() => {
     const handleResponse = (event: MessageEvent) => {
       const { data: eventData } = event
-      // $FlowFixMe[incompatible-type] - eventData can be various types
       if (eventData && typeof eventData === 'object' && eventData.type === 'RESPONSE' && eventData.payload) {
-        // $FlowFixMe[prop-missing] - payload structure is validated above
         const payload = eventData.payload
-        // $FlowFixMe[prop-missing] - payload structure is validated above
         if (payload && typeof payload === 'object') {
           const correlationId = (payload: any).correlationId
           const success = (payload: any).success

--- a/dwertheimer.TaskAutomations/src/NPOverdue.js
+++ b/dwertheimer.TaskAutomations/src/NPOverdue.js
@@ -254,7 +254,6 @@ export async function reviewOverdueTasksInNote(incoming: string): Promise<void> 
         noteTaskList: (overdues: any),
         overdueOnly: true,
       }
-      // $FlowIgnore
       const notesToReview = getNotesAndTasksToReview(options)
       clo(notesToReview, 'reviewOverdueTasksInNote: notesToReview')
       await reviewOverdueTasksByNote(notesToReview, options)
@@ -299,7 +298,6 @@ export async function reviewWeeklyTasks(forDateString?: string = getTodaysDateHy
  */
 export async function reviewEditorReferencedTasks(byTask: boolean = true, weeklyNote: boolean = false, forDateString?: string = getTodaysDateHyphenated()): Promise<void> {
   try {
-    // $FlowFixMe
     await Editor.openNoteByDate(new moment(forDateString || undefined).toDate())
     logDebug(pluginJson, `reviewEditorReferencedTasks: ${String(byTask)}, ${String(weeklyNote)}`)
     if (Editor.note?.type !== 'Calendar') {

--- a/dwertheimer.TaskSorting/src/sortTasks.js
+++ b/dwertheimer.TaskSorting/src/sortTasks.js
@@ -205,7 +205,6 @@ export async function openTasksToTop(
         rawContent.push(taskPara.raw)
 
         // Add all children content (not just tasks)
-        // $FlowIgnore[method-unbinding] - these are SortableParagraphSubset entries from getTasksByType(),
         // whose `children` is an array property, not the NotePlan API method of the same name.
         if (taskPara.children && taskPara.children.length) {
           taskPara.children.forEach((child) => {
@@ -217,7 +216,6 @@ export async function openTasksToTop(
         rawContent.push(taskPara.raw)
 
         // Add child tasks (but not other content like notes, quotes)
-        // $FlowIgnore[method-unbinding] - these are SortableParagraphSubset entries from getTasksByType(),
         // whose `children` is an array property, not the NotePlan API method of the same name.
         if (taskPara.children && taskPara.children.length) {
           taskPara.children.forEach((child) => {
@@ -631,9 +629,7 @@ async function deleteExistingTasks(note: CoreNoteFields, tasks: GroupedTasks): P
         }
 
         // Also include children if they exist
-        // $FlowIgnore[method-unbinding] - `children` is an array property on SortableParagraphSubset, not the NotePlan API method
         if (taskPara.children && taskPara.children.length) {
-          // $FlowIgnore[method-unbinding]
           taskPara.children.forEach((child) => {
             if (child.paragraph) {
               tasksToDelete.push(child.paragraph)

--- a/helpers/HTMLView.js
+++ b/helpers/HTMLView.js
@@ -594,7 +594,6 @@ export async function showHTMLV2(body: string, opts: HtmlWindowOptions): Promise
           reloadPluginID: opts.reloadPluginID,
           reloadCommandName: opts.reloadCommandName,
         }
-        // $FlowFixMe[incompatible-type] - Flow can't guarantee the Promise resolves to an object
         const mainWindowResult = await HTMLView.showInMainWindow(fullHTMLStr, opts.windowTitle ?? '', mainWindowSpecificOptions)
         if (mainWindowResult && mainWindowResult.success) {
           success = true

--- a/helpers/NPCalendar.js
+++ b/helpers/NPCalendar.js
@@ -140,7 +140,6 @@ export async function writeTimeBlocksToCalendar(config: EventsConfig, note: TNot
       logWarn('NPCalendar / writeTimeBlocksToCalendar', 'no content found')
       return
     }
-    // $FlowFixMe - Flow doesn't like note or Editor being called here. But for these purposes they should be identical
     const noteTitle = displayTitle(note)
     logDebug('NPCalendar / writeTimeBlocksToCalendar', `Starting for note '${noteTitle}' ...`)
 
@@ -157,7 +156,6 @@ export async function writeTimeBlocksToCalendar(config: EventsConfig, note: TNot
     }
 
     // Look through open note to find valid time blocks, but stop at Done or Cancelled sections
-    // $FlowIgnore - Flow doesn't like note or Editor being called here. But for these purposes they should be identical
     const endOfActive = findEndOfActivePartOfNote(note)
     const timeblockParas = paragraphs.filter((p) => isTimeBlockPara(p) && p.lineIndex <= endOfActive && ((p.type !== 'done' && p.type !== 'checklistDone') || config.includeCompletedTasks))
     if (timeblockParas.length > 0) {

--- a/helpers/NPFrontMatter.js
+++ b/helpers/NPFrontMatter.js
@@ -1071,7 +1071,6 @@ export function updateFrontMatterVars(note: TEditor | TNote, newAttributes: { [s
       }
       logDebug('updateFrontMatterVars', `normalizedValue for key: ${canonicalKey} = ${normalizedValue}`)
 
-      // $FlowIgnore
       normalizedNewAttributes[canonicalKey] = normalizedValue
     })
 
@@ -1094,7 +1093,6 @@ export function updateFrontMatterVars(note: TEditor | TNote, newAttributes: { [s
 
     // Update existing attributes -- just replace the text in the paragraph
     keysToUpdate.forEach((key: string) => {
-      // $FlowIgnore
       const attributeLine = `${key}: ${normalizedNewAttributes[key]}`
       const keyPrefixRe = new RegExp(`^${key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}:`, 'i')
       const paragraph = note.paragraphs.find((para) => keyPrefixRe.test(para.content))
@@ -1110,7 +1108,6 @@ export function updateFrontMatterVars(note: TEditor | TNote, newAttributes: { [s
 
     // Add new attributes to the end of the frontmatter
     keysToAdd.forEach((key) => {
-      // $FlowIgnore
       const newAttributeLine = `${key}: ${normalizedNewAttributes[key]}`
       // Insert before the closing '---'
       // clo(note.paragraphs, `updateFrontMatterVars: note.paragraphs`)

--- a/helpers/NPMoveItems.js
+++ b/helpers/NPMoveItems.js
@@ -315,7 +315,6 @@ export function moveParagraphToNote(para: TParagraph, destinationNote: TNote): b
   // Use rawContent instead of content for more reliable matching
   if (noteHasRawContent(destinationNote, para.rawContent)) {
     para?.note?.removeParagraph(para) // this may not work if you are using Editor.* commands rather than Editor.note.* commands
-    // $FlowFixMe - not in the type defs yet
     DataStore.updateCache(oldNote) // try to force Editor and Editor.note to be in sync after the move
     return true
   } else {

--- a/helpers/NPParagraph.js
+++ b/helpers/NPParagraph.js
@@ -1017,7 +1017,6 @@ export function hasOverdueTag(para: TParagraph, returnDetails: boolean = false, 
 export function getOverdueTags(para: TParagraph, asOfDayString?: string = ''): string[] {
   const funcs = [hasOverdueDayTag, hasOverdueWeekTag, hasOverdueMonthTag, hasOverdueQuarterTag, hasOverdueYearTag]
   return funcs.reduce((acc, func) => {
-    // $FlowIgnore - flow doesn't know what the signature of the functions is
     const tagList = func(para, true, asOfDayString)?.overdueLinks || []
     // $FlowIgnore - see above
     return [...acc, ...tagList]
@@ -1242,14 +1241,12 @@ export function paragraphMatches(paragraph: TParagraph, fieldsObject: any, field
         match = false
       }
     } else if (field === 'rawContent') {
-      // $FlowIgnore[prop-missing]
       if (typeof paragraph[field] === 'undefined') {
         throw `paragraphMatches: paragraph.${field} is undefined. You must pass in the correct fields to match. 'fields' is set to ${JSP(fields)}, but paragraph=${JSP(
           paragraph,
         )}, which does not have all the fields`
       }
       // Exact match, or match ignoring leading indent (backlinks strip indent from rawContent)
-      // $FlowIgnore[prop-missing]
       if (!rawContentMatchesIgnoringLeadingIndent(paragraph[field], fieldsObject[field])) {
         match = false
       }
@@ -1324,7 +1321,6 @@ export function findParagraph(
     // const p = paragraphDataToFind
     logDebug(pluginJson, `findParagraph: found no paragraphs in note "${paragraphDataToFind.filename}" that matches ${JSON.stringify(paragraphDataToFind.rawContent)}`)
     // logDebug(`\n**** Looking for "${p[fieldsToMatch[0]]}" "${p[fieldsToMatch[1]]}" in the following list`)
-    //$FlowIgnore
     // parasToLookIn.forEach((p) => logDebug(pluginJson, `\t findParagraph: ${p[fieldsToMatch[0]]} ${p[fieldsToMatch[1]]}`))
   }
   return null

--- a/helpers/NPReminders.js
+++ b/helpers/NPReminders.js
@@ -77,11 +77,9 @@ function titlesAndColorsFromReminderListObjects(lists: $ReadOnlyArray<any>): TRe
   const titles: Array<string> = []
   for (const list of lists) {
     // availableReminderLists returns list objects with title + color (typed loosely as TCalendarItem)
-    // $FlowFixMe[prop-missing]
     const title: string = list.title || ''
     if (!title || title.trim() === '') continue
     titles.push(title)
-    // $FlowFixMe[prop-missing]
     const listColor: ?string = list.color
     if (listColor && typeof listColor === 'string' && listColor.trim() !== '') {
       colorByTitle[title] = listColor

--- a/helpers/NPWindows.js
+++ b/helpers/NPWindows.js
@@ -908,7 +908,6 @@ export async function setEditorWindowWidth(editorWinIn?: number, widthIn?: numbe
  * @param {EditorWinDetails | HTMLWinDetails} winDetails
  * @returns {EditorWinDetails | HTMLWinDetails} constrained winDetails
  */
-// $FlowFixMe[incompatible-return]
 // export function constrainWindowSizeAndPosition(winDetails: EditorWinDetails | HTMLWinDetails): EditorWinDetails | HTMLWinDetails {
 export function constrainWindowSizeAndPosition<T: { x: number, y: number, width: number, height: number, ... }>(winDetails: T): T {
   try {

--- a/helpers/NPdateTime.js
+++ b/helpers/NPdateTime.js
@@ -853,9 +853,7 @@ export function getNPWeekData(dateIn: string | Date = new Date(), offsetIncremen
       // Note: In some environments the Calendar API can return non-Date objects (e.g. {}) during early startup / WebView contexts.
       // In WebView, startOfWeek/endOfWeek often return Thenables (Promises) that sync code cannot await.
       // Treat both as equivalent to Calendar being unavailable and fall back to moment-based week boundaries.
-      // $FlowIgnore[incompatible-type]
       startDate = Calendar.startOfWeek(date)
-      // $FlowIgnore[incompatible-type]
       endDate = Calendar.endOfWeek(date)
       const startIsThenable = isThenable(startDate)
       const endIsThenable = isThenable(endDate)
@@ -1215,7 +1213,6 @@ export function getRelativeDates(useISODailyDates: boolean = false): Array<Relat
     // Weeks
     // Note: can't start with moment as NP weeks count differently
     const addRelativeWeek = (relName: string, offset: number = 0): void => {
-      // $FlowIgnore[incompatible-type]
       const thisNPWeekInfo: ?NotePlanWeekInfo = getNPWeekData(new Date(), offset)
       if (!thisNPWeekInfo || !thisNPWeekInfo.weekString) {
         logWarn('NPdateTime::getRelativeDates', `Couldn't calculate '${relName}' (offset=${String(offset)}), skipping`)
@@ -1600,9 +1597,7 @@ export function formatNPWeek(date: Date): string {
   // Use NotePlan's Calendar API when available (respects user's week start preference)
   if (typeof Calendar !== 'undefined' && Calendar && typeof Calendar.weekNumber === 'function') {
     const weekNumber = Calendar.weekNumber(date)
-    // $FlowIgnore[incompatible-type]
     const startDate = Calendar.startOfWeek(date)
-    // $FlowIgnore[incompatible-type]
     const endDate = Calendar.endOfWeek(date)
     const startIsThenable = isThenable(startDate)
     const endIsThenable = isThenable(endDate)

--- a/helpers/NPdev.js
+++ b/helpers/NPdev.js
@@ -37,7 +37,6 @@ export async function chooseRunPluginXCallbackURL(
       plugin.commands?.forEach((command) => {
         const show = `${command.name} (${plugin.name})`
         if (filterCommandRegex && !filterCommandRegex.test(show)) return
-        // $FlowIgnore
         commandMap.push({
           name: command.name,
           description: command.desc,

--- a/helpers/NPnote.js
+++ b/helpers/NPnote.js
@@ -394,7 +394,6 @@ export async function printNote(noteIn: ?TNote, alsoShowParagraphs: boolean = fa
     if (note.backlinks?.length > 0) {
       console.log(`Backlinks:`)
       console.log(`- ${String(note.backlinks.length)} backlinked note(s)`)
-      // $FlowIgnore[prop-missing]
       const flatBacklinkParas = getFlatListOfBacklinks(note) ?? [] // Note: this requires DataStore
       console.log(`- ${String(flatBacklinkParas.length)} backlink paras:`)
       for (let i = 0; i < flatBacklinkParas.length; i++) {
@@ -896,7 +895,6 @@ export async function openNoteByFilename(filename: string, options: OpenNoteOpti
     const dataStoreNote = isCalendarNote ? await DataStore.noteByFilename(filename, 'Calendar') : null
     if (dataStoreNote) {
       dataStoreNote.content = ''
-      // $FlowIgnore[incompatible-call]
       note = await Editor.openNoteByFilename(
         filename,
         options.newWindow || false,
@@ -1576,7 +1574,6 @@ export async function getNoteFromParamOrUser(purpose: string, noteTitleArg: stri
     const possDateStr = getDateStrFromRelativeDateString(noteTitleArg)
     if (possDateStr !== '') {
       noteTitleArgIsCalendarNote = true
-      // $FlowFixMe[incompatible-type]
       note = getOrMakeCalendarNote(possDateStr)
       if (note != null) {
         logDebug('getNoteFromParamOrUser', `Found match with relative date '${noteTitleArg}' = filename ${note?.filename ?? '(error)'}`)

--- a/helpers/__tests__/syncedCopies.test.js
+++ b/helpers/__tests__/syncedCopies.test.js
@@ -85,7 +85,6 @@ describe('syncedCopies', () => {
   // ---------------------------------------------------
 
   describe('eliminateDuplicateParagraphs', () => {
-    // $FlowFixMe[missing-local-annot] - Test helper function
     const createMockParagraph = (content: string, filename: string, blockId: ?string = '', noteType: string = 'Notes', changedDate: Date = new Date()) => ({
       content,
       filename,
@@ -108,7 +107,6 @@ describe('syncedCopies', () => {
     })
 
     test('should return single paragraph unchanged', () => {
-      // $FlowIgnore[incompatible-call] - Test mock objects
       const paras = [createMockParagraph('Task 1', 'note1.md', 'block1')]
       // $FlowIgnore[prop-missing]
       // $FlowIgnore[incompatible-call]

--- a/helpers/dateTime.js
+++ b/helpers/dateTime.js
@@ -1633,7 +1633,6 @@ export function getDateOptions(): $ReadOnlyArray<{ label: string, value: string 
 
   const options = inputs.map((i) => ({
     label: `${i['l']} ${format(i['d'], formats[i['lf']])}`,
-    // $FlowIgnore
     value: format(i['d'], formats[i['vf']]),
   }))
   return options

--- a/helpers/react/DynamicDialog/HeadingChooser.jsx
+++ b/helpers/react/DynamicDialog/HeadingChooser.jsx
@@ -301,7 +301,6 @@ export function HeadingChooser({
       return option.shortDescription || null
     },
     truncateDisplay: truncateText,
-    // $FlowFixMe[incompatible-type] - Flow can't properly narrow union type in onSelect handler
     onSelect: (option: any) => {
       // Handle both regular selections and manual entries
       // Type guard: check if this is a manual entry option

--- a/helpers/react/DynamicDialog/NoteChooser.jsx
+++ b/helpers/react/DynamicDialog/NoteChooser.jsx
@@ -967,7 +967,6 @@ export function NoteChooser({
         (() => {
           const body = document.body
           if (!body) return null
-          // $FlowFixMe[incompatible-call] - document.body is checked for null above
           return createPortal(
             <div
               ref={calendarPickerRef}

--- a/helpers/react/DynamicDialog/OrderingPanel.jsx
+++ b/helpers/react/DynamicDialog/OrderingPanel.jsx
@@ -186,7 +186,6 @@ const OrderingPanel = ({
         e.dataTransfer.setDragImage(dragImage, 0, 0)
         setTimeout(() => {
           if (document.body && dragImage.parentNode) {
-            // $FlowIgnore[incompatible-use]
             document.body.removeChild(dragImage)
           }
         }, 0)

--- a/helpers/react/IdleTimer.jsx
+++ b/helpers/react/IdleTimer.jsx
@@ -55,7 +55,6 @@ function IdleTimer({ idleTime, onIdleTimeout }: IdleTimerProps): React$Node {
     }
 
     const handleVisibilityChange = () => {
-      // $FlowIgnore
       if (document.visibilityState === 'visible') {
         setLastActivity(Date.now())
         // Reset the timeout flag when user becomes active
@@ -66,14 +65,12 @@ function IdleTimer({ idleTime, onIdleTimeout }: IdleTimerProps): React$Node {
     window.addEventListener('mousemove', handleUserActivity)
     window.addEventListener('keydown', handleUserActivity)
     window.addEventListener('scroll', handleUserActivity)
-    // $FlowIgnore
     document.addEventListener('visibilitychange', handleVisibilityChange)
 
     return () => {
       window.removeEventListener('mousemove', handleUserActivity)
       window.removeEventListener('keydown', handleUserActivity)
       window.removeEventListener('scroll', handleUserActivity)
-      // $FlowIgnore
       document.removeEventListener('visibilitychange', handleVisibilityChange)
     }
   }, [])

--- a/helpers/sorting.js
+++ b/helpers/sorting.js
@@ -298,6 +298,5 @@ export function getTasksByType(paragraphs: $ReadOnlyArray<TParagraph>, ignoreInd
 
   // logDebug('getTasksByType', `\tgetTasksByType Open Tasks:${String(tasks.open.length)} returning from getTasksByType`)
   // logDebug('getTasksByType', `\tgetTasksByType Open Checklists:${String(tasks.checklist.length)} returning from getTasksByType`)
-  // $FlowFixMe - Flow doesn't like that I am ensuring that all the keys are in the object using reduce above
   return tasks
 }

--- a/helpers/userInput.js
+++ b/helpers/userInput.js
@@ -109,7 +109,6 @@ export async function chooseOptionWithModifiers<T, TDefault = T>(
 
   // logDebug('userInput / chooseOptionWithModifiers()', `displayOptions: ${ displayOptions.length } options`)
 
-  // $FlowFixMe[prop-missing]
   const { index, keyModifiers } = await CommandBar.showOptions(
     displayOptions.map((option) => (typeof option === 'string' ? option : option.label)),
     message,
@@ -1100,12 +1099,10 @@ export async function datePicker(dateParams: string | Object, config?: { [string
         : {}
     }
 
-    // $FlowIgnore[incompatible-type]
     logDebug('userInput / datePicker', `params: ${JSON.stringify(dateParams)} -> ${JSON.stringify(paramConfig)}`)
     // '...' = "gather the remaining parameters into an array"
     const allSettings: { [string]: mixed } = {
       // $FlowIgnore[exponential-spread] known to be very small objects
-      // $FlowIgnore[not-an-object]
       ...dateConfig,
       // $FlowIgnore[not-an-object]
       ...paramConfig,

--- a/jgclark.Dashboard/src/__tests__/dashboardSettingsDefaults.test.js
+++ b/jgclark.Dashboard/src/__tests__/dashboardSettingsDefaults.test.js
@@ -32,7 +32,6 @@ describe(`${PLUGIN_NAME}`, () => {
     test('getListOfEnabledSections() includes REM when showUndatedOverdueReminders is missing', () => {
       const defaults = getDashboardSettingsDefaults()
       const withoutKey = { ...defaults }
-      // $FlowIgnore[prop-missing]
       delete withoutKey.showUndatedOverdueReminders
       const enabled = getListOfEnabledSections(withoutKey)
       expect(enabled).toContain('REM')

--- a/jgclark.Dashboard/src/clickHandlers.js
+++ b/jgclark.Dashboard/src/clickHandlers.js
@@ -880,7 +880,6 @@ function getEnabledSectionCodesAmongCalendarVisibilityRefreshList(mergedSettings
   return SECTIONS_TO_REFRESH_AFTER_CHANGE_OF_VISIBILITY_OF_CALENDAR_SECTIONS.filter((code) => {
     const detail = allSectionDetails.find((s) => s.sectionCode === code)
     if (!detail?.showSettingName) return false
-    // $FlowIgnore[invalid-computed-prop]
     return mergedSettings[detail.showSettingName] !== false
   })
 }
@@ -898,7 +897,6 @@ function getNewlyEnabledCalendarSectionCodes(diffKeys: Array<string>, nextMerged
   for (const key of diffKeys) {
     const detail = allSectionDetails.find((d) => d.showSettingName === key)
     if (!detail || !allCalendarSectionCodes.includes(detail.sectionCode)) continue
-    // $FlowIgnore[invalid-computed-prop]
     if (nextMerged[key]) {
       codes.push(detail.sectionCode)
     }
@@ -969,8 +967,6 @@ function planSectionRefreshAfterDashboardSettingsChange(
   // $FlowIgnore[prop-missing]
   // $FlowIgnore[cannot-spread-indexer]
   const prevMerged: { [string]: any } = { ...defaults, ...priorDashboardSettingsSnapshot }
-  // $FlowIgnore[prop-missing]
-  // $FlowIgnore[cannot-spread-indexer]
   const nextMerged: { [string]: any } = { ...defaults, ...(settingsToSave || {}) }
   const oldTheme = String(prevMerged.dashboardTheme ?? '')
   const newTheme = String(nextMerged.dashboardTheme ?? '')

--- a/jgclark.Dashboard/src/dashboardHelpers.js
+++ b/jgclark.Dashboard/src/dashboardHelpers.js
@@ -148,7 +148,6 @@ export async function getDashboardSettings(): Promise<TDashboardSettings> {
     } else {
       // Merge with defaults to ensure any new settings are added (existing settings take precedence)
       const defaults: TAnyObject = getDashboardSettingsDefaults()
-      // $FlowIgnore[cannot-spread-indexer]
       parsedDashboardSettings = { ...defaults, ...parsedDashboardSettings, showSearchSection: true }
 
       // Migration: Convert old showProjectSection to showProjectReviewSection
@@ -190,7 +189,6 @@ export async function getDashboardSettings(): Promise<TDashboardSettings> {
     logError('getDashboardSettings', `${err.name}: ${err.message}`)
     logWarn('getDashboardSettings', `Returning defaults after load error`)
     const defaults = getDashboardSettingsDefaults()
-    // $FlowFixMe[prop-missing]
     return ({ ...defaults, showSearchSection: true }: any)
   }
 }
@@ -605,7 +603,6 @@ function getReferencedOpenParagraphs(
 
   // Get list of allowed folders (using both include and exclude settings)
   const allowedFoldersInCurrentPerspective = getCurrentlyAllowedFolders(dashboardSettings)
-  // $FlowIgnore[incompatible-call] - p.note almost guaranteed to exist
   logDebug('getReferencedOpenParagraphs: refOpenParas', refOpenParas.map((p) => p.note?.filename ?? '<no note>'))
 
   // Filter by teamspace first

--- a/jgclark.Dashboard/src/dashboardSettings.js
+++ b/jgclark.Dashboard/src/dashboardSettings.js
@@ -597,7 +597,6 @@ export function normaliseDashboardNumberSettings(settingsIn: TAnyObject): TAnyOb
         return
       }
       const key: string = def.key
-      // $FlowIgnore[prop-missing]
       const rawValue: any = settingsOut[key]
       if (rawValue === null || rawValue === undefined) {
         return
@@ -608,7 +607,6 @@ export function normaliseDashboardNumberSettings(settingsIn: TAnyObject): TAnyOb
 
       const coerced = Number(rawValue)
       if (!Number.isNaN(coerced)) {
-        // $FlowIgnore[prop-missing]
         settingsOut[key] = coerced
       }
     })

--- a/jgclark.Dashboard/src/dashboardSettingsDefaults.js
+++ b/jgclark.Dashboard/src/dashboardSettingsDefaults.js
@@ -46,7 +46,6 @@ export function getDashboardSettingsDefaults(): TDashboardSettings {
   sectionDefaults.showCurrentReminders = true
 
   // clo(dashboardSettingsDefaults, `dashboardSettingsDefaults:`)
-  // $FlowIgnore[cannot-spread-indexer]
   return ({ ...dashboardSettingsDefaults, ...sectionDefaults }: any)
 }
 

--- a/jgclark.Dashboard/src/dataGenerationOverdue.js
+++ b/jgclark.Dashboard/src/dataGenerationOverdue.js
@@ -115,7 +115,6 @@ export async function getOverdueSectionData(
         const beforeMerge = dashboardParas.length
         // Cast: removeDuplicates() is typed over a generic indexed object, so its result no longer
         // carries the exact TParagraphForDashboard shape even though the elements are unchanged.
-        // $FlowFixMe[incompatible-call]
         dashboardParas = (removeDuplicates(dashboardParas.concat(yesterdaySpillDashboardParas), ['filename', 'content']): any)
         logDebug(
           'getOverdueSectionData',
@@ -274,7 +273,6 @@ export async function getRelevantOverdueTasks(
     logTimer('getRelevantOverdueTasks', thisStartTime, `- after filtering by allowed teamspaces, ${filteredOverdueParas.length} overdue items`)
 
     // Filter out items in non-valid folders
-    // $FlowFixMe[incompatible-call]
     filteredOverdueParas = filterParasByRelevantFolders(filteredOverdueParas, dashboardSettings, thisStartTime, 'getRelevantOverdueTasks')
     logTimer('getRelevantOverdueTasks', thisStartTime, `- after filtering by valid folders, ${filteredOverdueParas.length} overdue items`)
 

--- a/jgclark.Dashboard/src/dataGenerationProjects.js
+++ b/jgclark.Dashboard/src/dataGenerationProjects.js
@@ -28,7 +28,6 @@ function makeProjectRowItem(sectionCode: TSectionCode, project: any, itemCount: 
     ID: thisID,
     sectionCode: sectionCode,
     itemType: 'project',
-    // $FlowIgnore[prop-missing]
     project: {
       filename: thisFilename,
       isTeamspace: parsedPossibleTeamspace?.isTeamspace ?? false,

--- a/jgclark.Dashboard/src/dataGenerationReminders.js
+++ b/jgclark.Dashboard/src/dataGenerationReminders.js
@@ -134,7 +134,6 @@ export async function getRemindersGeneratedData(
     // Form fields for the heading add-Reminder button (CommandButton -> showDialog)
     const reminderFormFields: Array<TSettingItem> = [
       { type: 'input', label: 'Reminder:', key: 'text', focus: true },
-      // $FlowIgnore[incompatible-type]
       {
         type: 'dropdown-select',
         label: 'Reminder List:',

--- a/jgclark.Dashboard/src/dataGenerationTags.js
+++ b/jgclark.Dashboard/src/dataGenerationTags.js
@@ -111,7 +111,6 @@ export async function getTaggedSectionData(
             })
           }
           logTimer('getTaggedSectionData', thisStartTime, `- from CACHE found ${notesWithTag.length} notes with ${thisTag}`)
-          // $FlowIgnore[unsafe-arithmetic]
           // cacheLookupTime = new Date() - cachedOperationStartTime
           source = turnOnAPIComparison ? 'using CACHE + API' : 'using just CACHE'
         } else {
@@ -119,7 +118,6 @@ export async function getTaggedSectionData(
           logDebug('getTaggedSectionData', `- using API only for ${thisTag}`)
           // Note: this is slow (1-3ms per note, so 3-9s for 3250 notes).
           notesWithTag = findNotesMatchingHashtagOrMention(thisTag, true, true, true, [], WANTED_PARA_TYPES, '', false, true)
-          // $FlowIgnore[unsafe-arithmetic]
           // const APILookupTime = new Date() - thisStartTime
           logTimer('getTaggedSectionData', thisStartTime, `- from API only found ${notesWithTag.length} notes with ${thisTag}`)
           source = 'using API'
@@ -239,7 +237,6 @@ export async function getTaggedSectionData(
 
           for (const p of sortedTagParas) {
             const thisID = `${sectionID}-${itemCount}`
-            // $FlowIgnore[incompatible-call]
             items.push(createSectionItemObject(thisID, thisSectionCode, p))
             itemCount++
           }

--- a/jgclark.Dashboard/src/moveDayClickHandlers.js
+++ b/jgclark.Dashboard/src/moveDayClickHandlers.js
@@ -479,7 +479,6 @@ export async function scheduleAllOverdueOpenToToday(
     // Get paras for all overdue items in notes (full TParagraphs, not ReducedParagraphs).
     // Pass [] for yesterdaysParas on purpose: schedule-all should still move yesterday-dated overdue tasks.
     // (Section generation does pass DY paras for display dedupe when Yesterday is on.)
-    // $FlowIgnore[prop-missing]
     // eslint-disable-next-line no-unused-vars
     const { filteredOverdueParas, preLimitOverdueCount } = await getRelevantOverdueTasks(config, []) // Note: does not include open checklist items
     const overdueParas = filteredOverdueParas

--- a/jgclark.Dashboard/src/perspectiveClickHandlers.js
+++ b/jgclark.Dashboard/src/perspectiveClickHandlers.js
@@ -40,14 +40,12 @@ import { getGlobalSharedData } from '@helpers/HTMLView'
 async function getLiveDashboardSettingsForPerspectiveSave(settingsFromBridge?: TDashboardSettingsIn | TPerspectiveSettings): Promise<TDashboardSettings> {
   if (settingsFromBridge && typeof settingsFromBridge === 'object' && !Array.isArray(settingsFromBridge) && Object.keys(settingsFromBridge).length > 0) {
     const defaults = getDashboardSettingsDefaults()
-  // $FlowIgnore[cannot-spread-indexer]
     return { ...defaults, ...settingsFromBridge, showSearchSection: true }
   }
   const reactWindowData = await getGlobalSharedData(WEBVIEW_WINDOW_ID)
   const fromReact = reactWindowData?.pluginData?.dashboardSettings
   if (fromReact && typeof fromReact === 'object' && !Array.isArray(fromReact) && Object.keys(fromReact).length > 0) {
     const defaults = getDashboardSettingsDefaults()
-  // $FlowIgnore[cannot-spread-indexer]
     return { ...defaults, ...fromReact, showSearchSection: true }
   }
   return getDashboardSettings()

--- a/jgclark.Dashboard/src/perspectiveHelpers.js
+++ b/jgclark.Dashboard/src/perspectiveHelpers.js
@@ -75,7 +75,6 @@ Named perspectives
 const pluginID = 'jgclark.Dashboard' // pluginJson['plugin.id']
 
 const standardSettings = cleanDashboardSettingsInAPerspective(
-  // $FlowIgnore[incompatible-call]
   [...dashboardSettingDefs, ...dashboardFilterDefs, ...showSectionSettingItems].reduce((acc, s) => {
     if (s.key) {
       // $FlowIgnore[prop-missing]
@@ -109,7 +108,6 @@ export async function getPerspectiveSettingDefaults(): Promise<Array<TPerspectiv
     {
       name: 'Home',
       isModified: false,
-      // $FlowIgnore[incompatible-call]
       dashboardSettings: {
         ...dashboardSettingsWithPerspectiveDefaults,
         includedFolders: 'Home, Family',
@@ -122,7 +120,6 @@ export async function getPerspectiveSettingDefaults(): Promise<Array<TPerspectiv
     {
       name: 'Work',
       isModified: false,
-      // $FlowIgnore[incompatible-call]
       dashboardSettings: {
         ...dashboardSettingsWithPerspectiveDefaults,
         includedFolders: 'Work, Company',
@@ -213,8 +210,6 @@ export async function loadPerspectiveDefsFromPluginSettings(_logAllKeys: boolean
         return []
       }
       const dashboardSettings = await getDashboardSettings()
-      // $FlowFixMe[prop-missing]
-      // $FlowFixMe[incompatible-call]
       defaultPersp.dashboardSettings = { ...defaultPersp.dashboardSettings, ...cleanDashboardSettingsInAPerspective(dashboardSettings, true) }
       perspectiveSettings = replacePerspectiveDef(perspectiveSettings, defaultPersp)
       await savePerspectiveSettings(perspectiveSettings)
@@ -362,10 +357,8 @@ export function getPerspectiveLiveVsSavedDiff(
   const newSettingsWithDefaults = { ...dashboardSettingsDefaults, ...liveDashboardSettings }
   const cleanedDefSettings = cleanDashboardSettingsInAPerspective(perspectiveDef.dashboardSettings || {})
   const activePerspDefDashboardSettingsWithDefaults = { ...dashboardSettingsDefaults, ...cleanedDefSettings }
-  // $FlowFixMe[incompatible-call]
   const cleanedSettings = cleanDashboardSettingsInAPerspective(newSettingsWithDefaults)
   const activePerspDefShowTagSectionKeys = Object.keys(perspectiveDef.dashboardSettings || {}).filter((k) => k.startsWith('showTagSection_'))
-  // $FlowIgnore[prop-missing] - Dynamic property access for tag section keys
   const activePerspDefShowTagSectionObject = activePerspDefShowTagSectionKeys.reduce((acc, k) => {
     acc[k] = perspectiveDef.dashboardSettings[k]
     return acc
@@ -375,7 +368,6 @@ export function getPerspectiveLiveVsSavedDiff(
     ...activePerspDefDashboardSettingsWithDefaults,
     ...activePerspDefShowTagSectionObject,
   }
-  // $FlowFixMe[incompatible-call]
   const cleanedSavedSettings = cleanDashboardSettingsInAPerspective(activePerspDefDashboardSettingsWithDefaultsAndTAGs)
   const diff = compareObjects(cleanedSavedSettings, cleanedSettings, PERSPECTIVE_LIVE_VS_SAVED_COMPARE_OMIT)
   if (diff === null || Object.keys(diff).length === 0) return null

--- a/jgclark.Dashboard/src/pluginToHTMLBridge.js
+++ b/jgclark.Dashboard/src/pluginToHTMLBridge.js
@@ -248,7 +248,6 @@ export async function bridgeClickDashboardItem(data: MessageDataObject) {
     // Allow for a combination of button click and a content update
     if (updatedContent && data.actionType !== 'updateItemContent') {
       logDebug('bCDI', `content updated with another button press; need to update content first; new content: "${updatedContent}"`)
-      // $FlowIgnore[incompatible-call]
       result = doContentUpdate(data)
       if (result.success) {
         // update the content so it can be found in the cache now that it's changed - this is for all the cases below that don't use data for the content - TODO(later): ultimately delete this

--- a/jgclark.Dashboard/src/react/components/DialogForProjectItems.jsx
+++ b/jgclark.Dashboard/src/react/components/DialogForProjectItems.jsx
@@ -111,7 +111,6 @@ const DialogForProjectItems = ({ details: detailsMessageObject, onClose, positio
 
   useLayoutEffect(() => {
     // logDebug(`DialogForProjectItems`, `BEFORE POSITION detailsMessageObject`, detailsMessageObject)
-    // $FlowIgnore[incompatible-call]
     if (dialogRef) positionDialog(dialogRef)
     // logDebug(`DialogForProjectItems`, `AFTER POSITION detailsMessageObject`, detailsMessageObject)
   }, [])

--- a/jgclark.Dashboard/src/react/components/DialogForTaskItems.jsx
+++ b/jgclark.Dashboard/src/react/components/DialogForTaskItems.jsx
@@ -69,7 +69,6 @@ const DialogForTaskItems = ({ details: detailsMessageObject, onClose, positionDi
 
   useLayoutEffect(() => {
     // logDebug(`DialogForTaskItems`, `BEFORE POSITION dialogRef.current.style.topbounds=${String(dialogRef.current?.getBoundingClientRect().top) || ""}`)
-    // $FlowIgnore[incompatible-call]
     positionDialog(dialogRef)
     // logDebug(`DialogForTaskItems`, `AFTER POSITION dialogRef.current.style.top=${String(dialogRef.current?.style.top || '') || ""}`)
   }, [])

--- a/jgclark.Dashboard/src/react/components/Header/Header.jsx
+++ b/jgclark.Dashboard/src/react/components/Header/Header.jsx
@@ -249,7 +249,6 @@ const Header = ({ lastFullRefresh, onDropdownMenuOpenChange }: Props): React$Nod
     // clo(detailsMessageObject, 'handleButtonClick detailsMessageObject')
     // const currentContent = para.content
     logDebug(`Header handleButtonClick`, `Button clicked on controlStr: ${controlStr}, handlingFunction: ${handlingFunction}`)
-    // $FlowIgnore[prop-missing]
     // const updatedContent = inputRef?.current?.getValue() || ''
     // if (controlStr === 'update') {
     //   logDebug(`DialogForTaskItems`, `handleButtonClick - orig content: {${currentContent}} / updated content: {${updatedContent}}`)

--- a/jgclark.Dashboard/src/react/components/PerspectivesTable.jsx
+++ b/jgclark.Dashboard/src/react/components/PerspectivesTable.jsx
@@ -231,7 +231,6 @@ const PerspectivesTable = ({ perspectives, settingDefs, onSave, onCancel, labelP
                         console.error('Invalid key:', key)
                         return null // or handle the error as needed
                       }
-                      // $FlowIgnore
                       const value = perspective.dashboardSettings?.[key] ?? settingDef.default
                       const item = {
                         ...settingDef,

--- a/jgclark.Dashboard/src/react/components/ProjectItem.jsx
+++ b/jgclark.Dashboard/src/react/components/ProjectItem.jsx
@@ -101,7 +101,6 @@ function ProjectItem({ item, thisSection }: Props): Node {
         {/* {isFromTeamspace && teamspaceName}
         {folderNamePart && <span className="folderName">{folderNamePart}</span>}
         {item.project && (
-          // $FlowFixMe[incompatible-type] - TProjectForDashboard extends TNoteForDashboard, so this is safe
           <NoteTitleLink
             item={item}
             noteData={item.project}

--- a/jgclark.Dashboard/src/react/components/Section/Section.jsx
+++ b/jgclark.Dashboard/src/react/components/Section/Section.jsx
@@ -172,7 +172,6 @@ const Section = ({ section, onButtonClick, isViewVisible = true }: SectionProps)
       if (section.sectionCode === 'TB') {
         if (!isTBSectionVisibleInSettings(dashboardSettings)) return
       } else {
-        // $FlowIgnore[invalid-computed-prop]
         if ((dashboardSettings: TAnyObject)[section.showSettingName] === false) return
       }
     }
@@ -418,7 +417,6 @@ const Section = ({ section, onButtonClick, isViewVisible = true }: SectionProps)
   // FIXME: this is getting called 3 times per section, once for each of the 3 sections in the Dashboard (TB, TAG, PROJREVIEW/PROJACT)
   // FIXME: this is also getting called another set of times after lastUpdated: "UPDATE_DATA Setting firstRun to false after force initial load"
 
-  // $FlowIgnore[invalid-computed-prop]
   let hideSection =
     !items.length ||
     (section.sectionCode === 'TB'
@@ -678,7 +676,6 @@ const Section = ({ section, onButtonClick, isViewVisible = true }: SectionProps)
 
 // Memoize Section component to prevent re-renders when props haven't changed
 // This helps prevent cascading re-renders when pluginData changes but section prop is the same
-// $FlowFixMe[incompatible-type]
 const MemoizedSection = (React.memo(Section, (prevProps: SectionProps, nextProps: SectionProps): boolean => {
   // Only re-render if the section object reference changed
   // Note: This won't prevent re-renders from context changes, but will prevent prop-based re-renders

--- a/jgclark.Dashboard/src/react/components/Section/sectionHelpers.js
+++ b/jgclark.Dashboard/src/react/components/Section/sectionHelpers.js
@@ -472,20 +472,16 @@ export function sortSections(
     }
     
     if (a.sectionCode === 'TAG') {
-      // $FlowIgnore
       const orderB = orderMap[b.sectionCode] ?? maxIndex
       return tagPositionInMap - orderB
     }
     
     if (b.sectionCode === 'TAG') {
-      // $FlowIgnore
       const orderA = orderMap[a.sectionCode] ?? maxIndex
       return orderA - tagPositionInMap
     }
     
-    // $FlowIgnore
     const orderA = orderMap[a.sectionCode] ?? maxIndex
-    // $FlowIgnore
     const orderB = orderMap[b.sectionCode] ?? maxIndex
 
     if (orderA !== orderB) {

--- a/jgclark.Dashboard/src/react/components/SettingsDialog.jsx
+++ b/jgclark.Dashboard/src/react/components/SettingsDialog.jsx
@@ -89,7 +89,6 @@ const SettingsDialog = ({
 
   // Return whether the controlling setting item is checked or not
   function stateOfControllingSetting(item: TSettingItem): boolean {
-    // $FlowIgnore[invalid-computed-prop]
     return controllingSettingsState[item.dependsOnKey ?? ''] ?? false
   }
 

--- a/jgclark.Dashboard/src/react/support/uiElementRenderHelpers.js
+++ b/jgclark.Dashboard/src/react/support/uiElementRenderHelpers.js
@@ -147,7 +147,6 @@ export function renderItem({
             label={thisLabel}
             options={(item.options || []).map((option) => (typeof option === 'string' ? { label: option, value: option } : option))}
             value={item.value || ''}
-            // $FlowIgnore[incompatible-type]
             onChange={(option: Option) => {
               item.key && handleFieldChange(item.key, option.value)
               item.key && handleComboChange(item.key, { target: { value: option.value } })

--- a/jgclark.Dashboard/src/reactMain.js
+++ b/jgclark.Dashboard/src/reactMain.js
@@ -471,7 +471,6 @@ async function getDashboardSettingsFromPerspective(perspectiveSettings: TPerspec
     if (!prevDashboardSettings) throw new Error(`getDashboardSettingsFromPerspective: getDashboardSettings failed`)
 
     // Get defaults to ensure all section show settings are included
-    // $FlowIgnore[incompatible-call] - getDashboardSettingsDefaults is exported from dashboardHelpers
     const defaults = getDashboardSettingsDefaults()
 
     // apply the new perspective's settings to the main dashboard settings

--- a/jgclark.Dashboard/src/shared.js
+++ b/jgclark.Dashboard/src/shared.js
@@ -102,7 +102,6 @@ export function validateAndFlattenMessageObject(data: MessageDataObject): Valida
 		// Normalize filename: if toFilename was used, ensure filename is set in result
 		// $FlowIgnore[prop-missing]
 		if (!result.filename && result.toFilename) {
-			//$FlowIgnore[prop-missing]
 			result.filename = result.toFilename
 		}
 

--- a/jgclark.MOCs/src/MOCs.js
+++ b/jgclark.MOCs/src/MOCs.js
@@ -183,7 +183,6 @@ export async function makeMOC(filenameArg?: string, termsArg?: string): Promise<
         // dedupe results by making and unmaking it into a set
         let uniqNotes = resultNotes.filter((noteToUse, index, self) =>
           index === self.findIndex((t) => (
-            // $FlowFixMe[incompatible-use]
             t.filename === noteToUse.filename
           ))
         )
@@ -197,11 +196,9 @@ export async function makeMOC(filenameArg?: string, termsArg?: string): Promise<
             uniqNotes.sort((a, b) => (displayTitle(a).toUpperCase() < displayTitle(b).toUpperCase() ? -1 : 1))
             break
           case 'createdDate':
-            // $FlowFixMe[incompatible-use]
             uniqNotes.sort((a, b) => (a.createdDate > b.createdDate ? -1 : 1))
             break
           default: // updatedDate
-            // $FlowFixMe[incompatible-use]
             uniqNotes.sort((a, b) => (a.changedDate > b.changedDate ? -1 : 1))
             break
         }

--- a/jgclark.RepeatExtensions/src/repeatMain.js
+++ b/jgclark.RepeatExtensions/src/repeatMain.js
@@ -152,7 +152,6 @@ async function runTaskSorterAfterRepeatsImpl(
           // guard below then skips the cache update. Type-only cast; see LEFT report.
           : (noteToUse: any).note
       if (cacheNote != null) {
-        // $FlowIgnore[incompatible-call]
         DataStore.updateCache(cacheNote, false)
       }
       const sortFields = config.taskSortingOrder

--- a/jgclark.Reviews/src/allProjectsListHelpers.js
+++ b/jgclark.Reviews/src/allProjectsListHelpers.js
@@ -289,7 +289,6 @@ function getFolderFilterFingerprint(config: ReviewConfig): string {
 }
 
 function getFileAgeMs(prefName: string): number {
-  // $FlowFixMe[incompatible-call] - DataStore.preference returns mixed, but we handle it
   const prefValue: mixed = DataStore.preference(prefName)
   const timestamp: number = typeof prefValue === 'number' ? prefValue : 0
   const reviewListDate = new Date(timestamp)

--- a/jgclark.Reviews/src/projectClass.js
+++ b/jgclark.Reviews/src/projectClass.js
@@ -661,7 +661,6 @@ export class Project {
    */
   get isReadyForReview(): boolean {
     // logDebug(pluginJson, `isReadyForReview: ${this.title}:  ${String(this.nextReviewDays)} ${String(this.isPaused)}`)
-    // $FlowFixMe[invalid-compare]
     return !this.isPaused && !this.isCompleted && this.nextReviewDays != null && !isNaN(this.nextReviewDays) && this.nextReviewDays <= 0
   }
 
@@ -837,7 +836,6 @@ if (preserveEmpty) {
 attrs[singleKeyName] = this.getProjectTagsFrontmatterValue(singleKeyName)
 
 // Prefer open Editor when present; getOpenEditorFromFilename returns false (not null), so use || not ??
-// $FlowFixMe[incompatible-call]
 const success = updateFrontMatterVars(possibleThisEditor || noteForWrites, attrs)
 if (!success) {
   logError('updateProjectMetadata', `Failed to update frontmatter metadata for '${this.title}'`)

--- a/jgclark.Reviews/src/reviewHelpers.js
+++ b/jgclark.Reviews/src/reviewHelpers.js
@@ -892,7 +892,6 @@ function migrateProjectMetadataLineCore(
         }
       }
 
-      // $FlowFixMe[incompatible-call]
       const mergedOK = updateFrontMatterVars((note: any), fmAttrs)
       if (!mergedOK) {
         mergeFailedDetail = `frontmatter merge failed (${logContext})`

--- a/jgclark.Reviews/src/reviews.js
+++ b/jgclark.Reviews/src/reviews.js
@@ -823,7 +823,6 @@ async function finishReviewCoreLogic(note: CoreNoteFields, scrollPos: number = 0
         }
         clearNextReviewFrontmatterField(note)
         updateBodyMetadataInNote(note, [reviewedTodayString])
-        // $FlowIgnore[prop-missing]
         DataStore.updateCache(note, true)
         return
       }
@@ -861,7 +860,6 @@ async function finishReviewCoreLogic(note: CoreNoteFields, scrollPos: number = 0
       clearNextReviewFrontmatterField(note)
       // Update @review(date) on the note
       updateBodyMetadataInNote(note, [reviewedTodayString])
-      // $FlowIgnore[prop-missing]
       DataStore.updateCache(note, true)
     }
 

--- a/jgclark.Summaries/src/forCharts.js
+++ b/jgclark.Summaries/src/forCharts.js
@@ -186,7 +186,6 @@ export async function generateTaskCompletionStats(
             doneDate = moment(n.date).format('YYYY-MM-DD') // the note's date
           }
           // If we've found a task done in the right period, save
-          // $FlowIgnore[incompatible-call]
           if (doneDate && withinDateRange(doneDate, fromDateStr, toDateStr)) {
             addToObj(doneDate)
           }

--- a/np.Shared/src/NPReactLocal.js
+++ b/np.Shared/src/NPReactLocal.js
@@ -163,7 +163,6 @@ function assembleHTMLString(bodyHTML: string, generatedOptions: any, windowOptio
   fullHTML.push('<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, maximum-scale=1, viewport-fit=cover">')
 
   // Add preBodyScript using generateScriptTags
-  // $FlowFixMe - generatedOptions.preBodyScript can be array/string/ScriptObj
   const preScript = generateScriptTags((generatedOptions.preBodyScript: any) ?? '')
   if (preScript !== '') {
     fullHTML.push(preScript)
@@ -181,7 +180,6 @@ function assembleHTMLString(bodyHTML: string, generatedOptions: any, windowOptio
   fullHTML.push(bodyHTML)
 
   // Add postBodyScript using generateScriptTags
-  // $FlowFixMe - generatedOptions.postBodyScript can be array/string/ScriptObj
   const postScript = generateScriptTags((generatedOptions.postBodyScript: any) ?? '')
   if (postScript !== '') {
     fullHTML.push(postScript)
@@ -223,7 +221,6 @@ export async function onMessageFromHTMLView(incoming: string): Promise<any> {
  *  - debug - boolean - outputs debugging variables at the bottom of the screen
  * @author @dwertheimer
  */
-// $FlowFixMe - inexact object literal
 export function openReactWindow(globalData: any = null, windowOptions?: HtmlWindowOptions = {}): boolean {
   try {
     logDebug(pluginJson, `NPReactLocal.openReactWindow Starting ...`)
@@ -253,7 +250,6 @@ export function openReactWindow(globalData: any = null, windowOptions?: HtmlWind
  * @param {Object} windowOptions - window options including windowTitle, customId, etc.
  * @author @dwertheimer
  */
-// $FlowFixMe - inexact object literal
 export function showInMainWindow(globalData: any = null, windowOptions?: HtmlWindowOptions = {}): boolean {
   try {
     logDebug(pluginJson, `NPReactLocal.showInMainWindow Starting ...`)
@@ -266,7 +262,6 @@ export function showInMainWindow(globalData: any = null, windowOptions?: HtmlWin
     const fullHTMLStr = assembleHTMLString(bodyHTML, generatedOptions, windowOptions)
 
     // Use HTMLView.showInMainWindow instead of showHTMLV2
-    // $FlowFixMe[prop-missing] - showInMainWindow is available in NotePlan v3.20+
     const windowOptsAny = (windowOptions: any)
     const mainWindowOptions = {
       splitView: windowOptsAny.splitView ?? false,
@@ -279,7 +274,6 @@ export function showInMainWindow(globalData: any = null, windowOptions?: HtmlWin
       reloadCommandName: windowOptsAny.reloadCommandName || null,
       reloadCommandArgs: windowOptsAny.reloadCommandArgs || null,
     }
-    // $FlowFixMe[prop-missing] - showInMainWindow is available in NotePlan v3.20+
     HTMLView.showInMainWindow(fullHTMLStr, windowOptions.windowTitle || 'React Window', mainWindowOptions)
 
     // If wanted, also write this HTML to a file so we can work on it offline.

--- a/np.Shared/src/index.js
+++ b/np.Shared/src/index.js
@@ -70,7 +70,6 @@ export async function checkForWantedResources(pluginID: string, filesToCheck?: A
     // We want to check, so read this plugin's requiredSharedFiles
     const livePluginJson = await getPluginJson(pluginID)
     const requiredSharedFiles = livePluginJson['plugin.requiredSharedFiles'] ?? []
-    // $FlowFixMe
     logDebug(`${pluginID}/init/checkForWantedResources`, `plugin np.Shared is loaded 😄 and provides ${String(requiredSharedFiles.length)} files:`)
 
     // Double-check that the requiredSharedFiles can be accessed

--- a/np.Shared/src/react/Root.jsx
+++ b/np.Shared/src/react/Root.jsx
@@ -97,7 +97,6 @@ export function Root(/* props: Props */): Node {
   const [showSimpleDialogTest, setShowSimpleDialogTest] = useState<boolean>(false)
   const [simpleDialogExample, setSimpleDialogExample] = useState<number>(0)
 
-  // $FlowFixMe
   const tempSavedClicksRef = useRef<Array<TAnyObject>>([]) // temporarily store the clicks in the webview
 
   // Map to store pending requests for request/response pattern
@@ -218,7 +217,6 @@ export function Root(/* props: Props */): Node {
 
     const bannerMessage = { type, msg, timeout, color: colorClass, border: borderClass, icon: iconClass, floating }
     logDebug(`Root`, `showBanner: ${type} '${msg}'`)
-    // $FlowFixMe - bannerMessage object matches the expected shape
     setBannerMessage(bannerMessage)
   }, []) // State setters are stable, no dependencies needed
 
@@ -274,7 +272,6 @@ export function Root(/* props: Props */): Node {
 
     const toastMessage = { type, msg, timeout, color: colorClass, border: borderClass, icon: iconClass }
     logDebug(`Root`, `showToast: ${JSON.stringify(toastMessage, null, 2)}`)
-    // $FlowFixMe - toastMessage object matches the expected shape
     setToastMessage(toastMessage)
   }, []) // State setters are stable, no dependencies needed
 
@@ -403,7 +400,6 @@ export function Root(/* props: Props */): Node {
                 }
                 break
               case 'RETURN_VALUE' /* function called returned a value */:
-                // $FlowIgnore
                 // setMessageFromPlugin(payload)
                 break
               default:

--- a/np.Shared/src/requestHandlers/getAvailableCalendars.js
+++ b/np.Shared/src/requestHandlers/getAvailableCalendars.js
@@ -33,7 +33,6 @@ export function getAvailableCalendars(params: { writeOnly?: boolean } = {}, plug
     // even when writeOnly=false. This is why we offer "All NotePlan Enabled Calendars" option.
     // Note: Flow type definition shows 2 required params, but API accepts 1 param (2nd param optional from v3.20.0)
     // This matches the implementation in Forms plugin which works correctly at runtime
-    // $FlowFixMe[incompatible-call] - Flow type definition incorrectly shows 2 required params, but API accepts 1 param (2nd is optional)
     const calendars: Array<string> = (Calendar.availableCalendarTitles(writeOnly || false): any)
 
     const totalElapsed: number = Date.now() - startTime

--- a/np.Shared/src/requestHandlers/noteHelpers.js
+++ b/np.Shared/src/requestHandlers/noteHelpers.js
@@ -59,8 +59,6 @@ export function convertNoteToOption(note: TNote, overrideType?: ?string, include
   if (includeDecoration) {
     try {
       // Use the shared helper that works with both TNote and NoteOption
-      // $FlowFixMe[incompatible-call] - NoteOption is compatible with the union type TNote | NoteOption (both have filename, type, frontmatterAttributes)
-      // $FlowFixMe[prop-missing] - NoteOption doesn't need all TNote properties for decoration
       const decoration = getNoteDecorationForReact((option: any))
       if (decoration && decoration.icon && decoration.color) {
         option.decoration = {

--- a/np.Templating/__tests__/BasePromptHandler.test.js
+++ b/np.Templating/__tests__/BasePromptHandler.test.js
@@ -531,9 +531,7 @@ describe('BasePromptHandler', () => {
     })
 
     it('should handle null/undefined values', () => {
-      // $FlowFixMe - Testing with undefined
       expect(BasePromptHandler.removeQuotes('')).toBe('')
-      // $FlowFixMe - Testing with null
       expect(BasePromptHandler.removeQuotes('')).toBe('')
     })
   })

--- a/np.Templating/__tests__/NPTemplateRunner.test.js
+++ b/np.Templating/__tests__/NPTemplateRunner.test.js
@@ -213,9 +213,7 @@ describe('NPTemplateRunner', () => {
     NPnote.getOrMakeCalendarNote.mockResolvedValue(mockNote)
     // $FlowFixMe - Mock functions
     NPnote.chooseNoteV2.mockResolvedValue({ title: 'Chosen Note' })
-    // $FlowFixMe - Mock functions
     const userInput = require('@helpers/userInput')
-    // $FlowFixMe[prop-missing] - Mock function
     ;(userInput.chooseHeading: any).mockResolvedValue('Test Heading')
 
     const NPdateTime = require('@helpers/NPdateTime')
@@ -931,7 +929,6 @@ describe('NPTemplateRunner', () => {
     })
 
     test('should handle replaceHeading option', async () => {
-      // $FlowFixMe - Mock functions
       const NPParagraph = require('@helpers/NPParagraph')
       // $FlowFixMe - Mock function
       NPParagraph.findHeading.mockReturnValue({

--- a/np.Templating/__tests__/getRenderContext.test.js
+++ b/np.Templating/__tests__/getRenderContext.test.js
@@ -81,7 +81,6 @@ jest.mock('@helpers/NPEditor', () => ({
 }))
 
 // Mock NPTemplating as a global module alias
-// $FlowIgnore[underconstrained-implicit-instantiation]
 jest.mock(
   'NPTemplating',
   () => {
@@ -119,7 +118,6 @@ beforeAll(() => {
 describe('getRenderContext', () => {
   beforeEach(() => {
     // Reset NPTemplating setup state
-    // $FlowIgnore[prop-missing]
     NPTemplating.templateConfig = null
     DataStore.settings['_logLevel'] = 'none'
   })
@@ -228,7 +226,6 @@ describe('getRenderContext', () => {
       const customMethod = jest.fn().mockReturnValue('test result')
       const userData = {
         methods: {
-          // $FlowIgnore[missing-local-annot]
           calculateTotal: (a: number, b: number) => a + b,
           customMethod,
         },
@@ -250,7 +247,6 @@ describe('getRenderContext', () => {
           value: 100,
         },
         methods: {
-          // $FlowIgnore[missing-local-annot]
           double: (x: number) => x * 2,
         },
       }
@@ -427,7 +423,6 @@ describe('getRenderContext', () => {
   describe('Error handling', () => {
     it('should handle errors gracefully', async () => {
       // Mock NPTemplating.setup to throw an error
-      // $FlowIgnore[cannot-write]
       const originalSetup = NPTemplating.setup
       // $FlowIgnore[cannot-write]
       NPTemplating.setup = jest.fn<Array<any>, any>().mockRejectedValue(new Error('Setup failed'))

--- a/np.Templating/__tests__/promptAwaitIssue.test.js
+++ b/np.Templating/__tests__/promptAwaitIssue.test.js
@@ -20,7 +20,6 @@ describe('Prompt Await Issue Tests', () => {
     }
 
     // Mock userInput methods
-    // $FlowIgnore - jest mocking
     jest.mock(
       '@helpers/userInput',
       () => ({
@@ -37,7 +36,6 @@ describe('Prompt Await Issue Tests', () => {
     const userData = {}
 
     // Get the mocked function
-    // $FlowIgnore - jest mocked module
     const { askDateInterval } = require('@helpers/userInput')
 
     const result = ((await processPrompts(templateData, userData): any): TProcessPromptsSuccess)

--- a/np.Templating/__tests__/promptDate.test.js
+++ b/np.Templating/__tests__/promptDate.test.js
@@ -19,7 +19,6 @@ jest.mock('@helpers/userInput', () => ({
 }))
 
 // Get the mocked function
-// $FlowIgnore - jest mocked module
 const { datePicker } = require('@helpers/userInput')
 
 describe('PromptDateHandler', () => {

--- a/np.Templating/__tests__/promptDateInterval.test.js
+++ b/np.Templating/__tests__/promptDateInterval.test.js
@@ -11,7 +11,6 @@ import '../lib/support/modules/prompts' // Import to register all prompt handler
 /* global describe, test, expect, jest, beforeEach, beforeAll */
 
 // Mock the @helpers/userInput module
-// $FlowIgnore - jest mocking
 jest.mock('@helpers/userInput', () => ({
   askDateInterval: jest.fn<Array<any>, any>().mockImplementation((msg) => {
     return Promise.resolve('2023-01-01 to 2023-01-31')
@@ -19,7 +18,6 @@ jest.mock('@helpers/userInput', () => ({
 }))
 
 // Get the mocked function
-// $FlowIgnore - jest mocked module
 const { askDateInterval } = require('@helpers/userInput')
 
 describe('PromptDateIntervalHandler', () => {

--- a/np.Templating/__tests__/promptSafetyChecks.test.js
+++ b/np.Templating/__tests__/promptSafetyChecks.test.js
@@ -9,7 +9,6 @@ import '../lib/support/modules/prompts' // Import to register all prompt handler
 
 /* global describe, test, expect, jest, beforeEach, beforeAll */
 
-// $FlowFixMe - deliberately mocking for tests
 jest.mock(
   '@helpers/userInput',
   () => ({
@@ -35,9 +34,7 @@ describe('Prompt Safety Checks', () => {
 
     // Mock CommandBar methods for all tests
     global.CommandBar = {
-      // $FlowFixMe - Flow doesn't handle Jest mocks well
       textPrompt: jest.fn(() => Promise.resolve('Test Response')),
-      // $FlowFixMe - Flow doesn't handle Jest mocks well
       showOptions: jest.fn((options, message) => {
         return Promise.resolve({ index: 0, value: options[0] })
       }),

--- a/np.Templating/__tests__/templating.test.js
+++ b/np.Templating/__tests__/templating.test.js
@@ -34,7 +34,6 @@ const DEFAULT_TEMPLATE_CONFIG = {
   userLastName: '',
   userEmail: '',
   userPhone: '',
-  // $FlowFixMe
   services: {},
 }
 

--- a/np.Templating/lib/TemplatingEngine.js
+++ b/np.Templating/lib/TemplatingEngine.js
@@ -537,7 +537,6 @@ export default class TemplatingEngine {
    * @param {any} obj - The object to check
    * @returns {boolean} True if the object is an ES6 class, false otherwise
    */
-  // $FlowFixMe
   isClass(obj: any): boolean {
     const isCtorClass = obj.constructor && obj.constructor.toString().substring(0, 5) === 'class'
     if (obj.prototype === undefined) {

--- a/np.Templating/lib/core/templateManager.js
+++ b/np.Templating/lib/core/templateManager.js
@@ -132,10 +132,8 @@ export async function getFilteredTemplateList(
       // Check if template matches filters
       if (templateMatchesFilters(attributeValues, matches, exclude, filterValues)) {
         // We already checked note.title != null and note.filename above, so it's safe to use here
-        // $FlowFixMe - Flow doesn't understand that we've already filtered out null titles/filenames
         const title: string = (note.title: any) || ''
         const filename: string = (note.filename: any) || ''
-        // $FlowFixMe - Flow has issues with optional properties in object literals
         const result: { label: string, value: string, note?: TNote } = includeNoteObject ? { label: title, value: filename, note } : { label: title, value: filename }
         templateList.push(result)
       }
@@ -247,7 +245,6 @@ export async function chooseTemplate(tags?: any = '*', promptMessage: string = '
       return null
     }
 
-    // $FlowIgnore
     logDebug(pluginJson, `chooseTemplate: Found ${templateNotes.length} templates in ${timer(start)}`)
 
     // Use chooseNoteV2 to show decorated note selection (includes icons, colors, folder paths, etc.)
@@ -528,7 +525,6 @@ export async function createTemplate(title: string = '', metaData: any, content:
 
       let metaTagData = []
       for (const [key, value] of Object.entries(metaData)) {
-        // $FlowIgnore
         metaTagData.push(`${key}: ${value}`)
       }
       let templateContent = `---\ntitle: ${noteName || ''}\n${metaTagData.join('\n')}\n---\n`

--- a/np.Templating/lib/rendering/templateProcessor.js
+++ b/np.Templating/lib/rendering/templateProcessor.js
@@ -1834,7 +1834,6 @@ export async function execute(templateData: string = '', sessionData: any, templ
     if (!codeBlockHasComment(codeBlock) && blockIsJavaScript(codeBlock)) {
       const executeCodeBlock = codeBlock.replace('```templatejs\n', '').replace('```\n', '')
       try {
-        // $FlowIgnore
         let result = ''
 
         if (executeCodeBlock.includes('<%')) {
@@ -1892,7 +1891,6 @@ function restoreEventDateMethods(sessionData: Object): Object {
       const method = (format: string = 'YYYY MM DD'): string => moment(sessionData.data[valuePath]).format(format)
 
       // Add to methods object - TemplatingEngine will automatically spread to top level before render
-      // $FlowIgnore - We're dynamically adding this method
       enhancedData.methods[methodName] = method
     })
   }

--- a/np.Templating/lib/support/modules/FrontmatterModule.js
+++ b/np.Templating/lib/support/modules/FrontmatterModule.js
@@ -22,7 +22,6 @@ function coalesceNullFrontmatterValue(val: mixed): mixed {
 }
 
 export default class FrontmatterModule {
-  // $FlowIgnore
   constructor(NPTemplating: any = null) {
     if (NPTemplating) {
       // $FlowIgnore

--- a/np.Templating/lib/support/modules/NoteModule.js
+++ b/np.Templating/lib/support/modules/NoteModule.js
@@ -317,7 +317,6 @@ export default class NoteModule {
       // Normal usage: first param is heading text, second is includeHeading
       const headingText = String(headingTextOrEditor || '')
       const shouldIncludeHeading = Boolean(headingTextOrIncludeHeading)
-      // $FlowIgnore[incompatible-call] - getCurrentNote() is nullable; getBlockUnderHeading already no-ops on a missing note
       return getBlockUnderHeading((this.getCurrentNote(): any), headingText, shouldIncludeHeading)
     }
   }

--- a/np.Templating/lib/support/modules/TasksModule.js
+++ b/np.Templating/lib/support/modules/TasksModule.js
@@ -57,14 +57,12 @@ export default class TasksModule {
 
     if (calendarDatePattern.test(resolvedIdentifier)) {
       logDebug(pluginJson, `_getNoteByIdentifier: Attempting to get calendar note for date-like identifier: ${resolvedIdentifier}`)
-      // $FlowIgnore - DataStore is a global in NotePlan
       note = await DataStore.calendarNoteByDateString(resolvedIdentifier)
       if (!note) {
         logDebug(pluginJson, `_getNoteByIdentifier: Calendar note not found for identifier: ${resolvedIdentifier}`)
       }
     } else {
       logDebug(pluginJson, `_getNoteByIdentifier: Attempting to get project note by title: "${resolvedIdentifier}"`)
-      // $FlowIgnore - DataStore is a global in NotePlan
       const notes = await DataStore.projectNoteByTitle(resolvedIdentifier)
       if (notes && notes.length > 0) {
         note = notes[0]

--- a/np.Templating/lib/support/modules/UtilityModule.js
+++ b/np.Templating/lib/support/modules/UtilityModule.js
@@ -10,7 +10,6 @@ import { sprintf } from 'sprintf-js'
 export default class UtilityModule {
   config: any
   constructor(config: any = {}) {
-    // $FlowFixMe
     this.config = config
   }
 

--- a/np.Templating/lib/support/modules/notePlanWeather.js
+++ b/np.Templating/lib/support/modules/notePlanWeather.js
@@ -258,7 +258,6 @@ export async function getNotePlanWeather(
   longitude: number | null = null,
 ): Promise<string | any> {
   try {
-    // $FlowFixMe - NotePlan global is available at runtime
     // work around NotePlan api bug where 0 was not doing a lookup, so sending nulls instead
     const _latitude = !latitude && !longitude ? undefined : latitude
     const _longitude = !latitude && !longitude ? undefined : longitude

--- a/np.Templating/lib/support/modules/prompts/BasePromptHandler.js
+++ b/np.Templating/lib/support/modules/prompts/BasePromptHandler.js
@@ -699,7 +699,6 @@ export default class BasePromptHandler {
               result.promptMessage = allParams[1] || ''
               if (allParams.length > 2) {
                 const optionsValue = allParams[2] || ''
-                // $FlowFixMe - optionsValue is a string but result.options can be string | Array<string>
                 result.options = optionsValue
               }
             } else {
@@ -707,7 +706,6 @@ export default class BasePromptHandler {
               result.promptMessage = allParams[0] || ''
               if (allParams.length > 1) {
                 const optionsValue = allParams[1] || ''
-                // $FlowFixMe - optionsValue is a string but result.options can be string | Array<string>
                 result.options = optionsValue
               }
             }

--- a/np.Templating/lib/support/modules/quote.js
+++ b/np.Templating/lib/support/modules/quote.js
@@ -9,7 +9,6 @@
 export async function getDailyQuote(): Promise<string> {
   const response = await fetch(`https://zenquotes.io/api/random`, { timeout: 3000 })
   if (response) {
-    //$FlowIgnore[incompatible-call]
     const quoteLines = JSON.parse(response)
     if (quoteLines.length > 0) {
       const data = quoteLines[0]

--- a/np.Templating/lib/support/modules/weather.js
+++ b/np.Templating/lib/support/modules/weather.js
@@ -23,7 +23,6 @@ export const WEATHER_API_FALLBACK_MESSAGE =
 
 export async function getWeather(): Promise<string> {
   try {
-    // $FlowFixMe
     let response: any = await fetch(`https://wttr.in?format=3`, { timeout: 3000 })
     if (response) {
       response = response.startsWith('not found:')

--- a/np.Templating/lib/support/modules/weatherSummary.js
+++ b/np.Templating/lib/support/modules/weatherSummary.js
@@ -94,7 +94,6 @@ export async function getWeatherSummary(format: string): Promise<string> {
     logDebug(`getWeatherSummary: received response: ${jsonIn.length} chars`)
     if (jsonIn != null) {
       try {
-        // $FlowIgnore[incompatible-call]
         allWeatherData = JSON.parse(jsonIn)
       } catch (error) {
         logError(`'${error.message}' parsing Weather data lookup`)

--- a/np.Templating/lib/support/modules/wotd.js
+++ b/np.Templating/lib/support/modules/wotd.js
@@ -21,7 +21,6 @@ export async function getWOTD(params: any): Promise<string> {
 
     const result = await fetch(url, options)
 
-    // $FlowIgnore
     const data = JSON.parse(result)
 
     let word = data?.word

--- a/np.Templating/src/NPTemplateRunner.js
+++ b/np.Templating/src/NPTemplateRunner.js
@@ -70,7 +70,6 @@ export async function replaceNoteContents(note: CoreNoteFields, renderedTemplate
  */
 export async function handleHeadingSelection(note: CoreNoteFields, writeUnderHeading: string): Promise<string> {
   if (/<choose>/i.test(writeUnderHeading) || /<select>/i.test(writeUnderHeading)) {
-    // $FlowIgnore -- note does not exist on CoreNoteFields (only on Editor)
     return await chooseHeading(note, true)
   }
   return writeUnderHeading

--- a/np.Templating/src/Templating.js
+++ b/np.Templating/src/Templating.js
@@ -145,7 +145,6 @@ export async function templateInsert(templateName: string = ''): Promise<void> {
       logDebug(pluginJson, `templateInsert: about to checkAndProcessFolderAndNewNoteTitle`)
       if (templateNote && (await checkAndProcessFolderAndNewNoteTitle(templateNote, frontmatterAttributes))) return
 
-      // $FlowIgnore
       const renderedTemplate = await NPTemplating.render(frontmatterBody, frontmatterAttributes, { frontmatterProcessed: true })
       if (renderedTemplate == null) {
         logDebug(pluginJson, `templateInsert: render returned null (user likely cancelled a prompt); aborting`)
@@ -178,7 +177,6 @@ export async function templateAppend(templateName: string = ''): Promise<void> {
     logDebug('templateAppend', `Starting templateAppend with templateName=${templateName}`)
     if (Editor.type === 'Notes' || Editor.type === 'Calendar') {
       const content: string = Editor.content || ''
-      // $FlowIgnore
       const selectedTemplate = templateName.length > 0 ? templateName : await NPTemplating.chooseTemplate()
       let templateData, templateNote
       if (/<current>/i.test(selectedTemplate)) {
@@ -270,7 +268,6 @@ export async function templateInvoke(templateName?: string): Promise<void> {
           logError(pluginJson, `Unable to locate template: ${templateName} which was passed to templateExecute`)
         }
       }
-      // $FlowIgnore
       const selectedTemplate = selectedTemplateFilename ?? (await NPTemplating.chooseTemplate())
       const templateData = await NPTemplating.getTemplateContent(selectedTemplate)
       let { frontmatterBody, frontmatterAttributes } = await NPTemplating.renderFrontmatter(templateData)
@@ -285,7 +282,6 @@ export async function templateInvoke(templateName?: string): Promise<void> {
       const frontmatterWithMethods = Object.assign(frontmatterModule, frontmatterAttributes)
 
       let data = { ...frontmatterAttributes, frontmatter: frontmatterWithMethods }
-      // $FlowIgnore
       let renderedTemplate = await NPTemplating.render(frontmatterBody, data, { frontmatterProcessed: true })
       if (renderedTemplate == null) {
         logDebug(pluginJson, `templateInvoke: render returned null (user likely cancelled a prompt); aborting`)
@@ -575,7 +571,6 @@ export async function templateQuickNote(templateTitle: string = ''): Promise<voi
           },
         }
 
-        // $FlowIgnore
         let finalRenderedData = await NPTemplating.render(frontmatterBody, data, { frontmatterProcessed: true })
         if (finalRenderedData == null) {
           logDebug(pluginJson, `templateQuickNote: render returned null (user likely cancelled a prompt); aborting`)
@@ -799,7 +794,6 @@ export async function templateWeather(): Promise<string> {
     let weatherFormat = (templateConfig && templateConfig.weatherFormat) || ''
     weatherFormat = weatherFormat.length === 0 && templateConfig?.weatherFormat?.length > 0 ? templateConfig?.weatherFormat : weatherFormat
 
-    // $FlowIgnore
     const resolvedFormat = weatherFormat === undefined || weatherFormat === null || weatherFormat.trim().length === 0 ? undefined : weatherFormat
     const weather = await getNotePlanWeather(resolvedFormat, null, null, null)
 
@@ -812,7 +806,6 @@ export async function templateWeather(): Promise<string> {
 // $FlowIgnore
 export async function templateAdvice(): Promise<string> {
   try {
-    // $FlowIgnore
     const advice: string = await getAdvice()
 
     Editor.insertTextAtCursor(advice)
@@ -824,7 +817,6 @@ export async function templateAdvice(): Promise<string> {
 // $FlowIgnore
 export async function templateAffirmation(): Promise<string> {
   try {
-    // $FlowIgnore
     const affirmation: string = await getAffirmation()
 
     Editor.insertTextAtCursor(affirmation)
@@ -836,7 +828,6 @@ export async function templateAffirmation(): Promise<string> {
 // $FlowIgnore
 export async function templateVerse(): Promise<string> {
   try {
-    // $FlowIgnore
     const verse: string = await getVersePlain()
 
     Editor.insertTextAtCursor(verse)
@@ -848,7 +839,6 @@ export async function templateVerse(): Promise<string> {
 // $FlowIgnore
 export async function templateQuote(): Promise<string> {
   try {
-    // $FlowIgnore
     const verse: string = await getDailyQuote()
 
     Editor.insertTextAtCursor(verse)

--- a/np.ThemeChooser/src/NPThemeChooser.js
+++ b/np.ThemeChooser/src/NPThemeChooser.js
@@ -97,7 +97,6 @@ export async function getThemeChoice(lightOrDark: string = '', message: string =
     label: `${t.name} (${t.mode || ''})${isBuiltInTheme(t.filename) ? '' : ' - Custom Theme'}`,
     isBuiltIn: isBuiltInTheme(t.filename),
   }))
-  // $FlowIgnore
   themeOpts = sortListBy(themeOpts, ['isBuiltIn', 'label'])
   // clo(themeOpts, `getThemeChoice, themeOpts`)
   if (lightOrDark !== '') {
@@ -194,7 +193,6 @@ export async function copyCurrentTheme(
         await showMessage(`Theme "${themeName}" already exists. Please choose a different name.`)
         return
       } else {
-        // $FlowIgnore
         theme.name = themeName || ''
         const success = Editor.addTheme(JSON.stringify(theme), `${themeName}.json`)
         logDebug(pluginJson, `copyCurrentTheme saving theme success: ${String(success)}`)

--- a/np.Tidy/src/tidyMain.js
+++ b/np.Tidy/src/tidyMain.js
@@ -175,7 +175,6 @@ export async function removeDoneMarkers(params: string = ''): Promise<void> {
 
     // Now map from paras -> notes and dedupe
     let numToRemove = allMatchedParas.length
-    // $FlowFixMe[incompatible-call]
     const recentMatchedNotes = recentMatchedParas.map((p) => p.note)
     // Dedupe this list
     const dedupedMatchedNotes = [...new Set(recentMatchedNotes)]
@@ -273,7 +272,6 @@ export async function removeDoneTimeParts(params: string = ''): Promise<void> {
 
     // Now map from paras -> notes and dedupe
     let numToRemove = allMatchedParas.length
-    // $FlowFixMe[incompatible-call]
     const recentMatchedNotes = recentMatchedParas.map((p) => p.note)
     // Dedupe this list
     const dedupedMatchedNotes = [...new Set(recentMatchedNotes)]
@@ -448,7 +446,6 @@ export async function removeOrphanedBlockIDs(params: string = ''): Promise<void>
 
     // Use numDays to limit to recent notes, if > 0
     if (config.numDays > 0) {
-      // $FlowFixMe[incompatible-call]
       const allMatchedNotes = parasWithBlockID.map((p) => p.note)
       // logDebug('allMatchedNotes', String(allMatchedNotes.length))
       const recentMatchedNotes = getNotesChangedInIntervalFromList(allMatchedNotes.filter(Boolean), config.numDays ?? 0)

--- a/scripts/releases.js
+++ b/scripts/releases.js
@@ -36,7 +36,6 @@
 const TEST = false // when set to true, doesn't actually create or delete anything. Just a dry run
 const COMMAND = 'Plugin Release'
 
-// $FlowIgnore
 const fs = require('fs/promises')
 const path = require('path')
 const colors = require('chalk')
@@ -331,11 +330,9 @@ async function getReleaseFileList(pluginDevDirFullPath, appPluginsPath, dependen
 
   let name
   if ((name = existingFileName('changelog.md'))) {
-    //$FlowFixMe - see note above
     fileList.changelog = fullPath(name)
   } else {
     if ((name = existingFileName('readme.md'))) {
-      //$FlowFixMe - see note above
       fileList.changelog = fullPath(name)
     } else {
       Messenger.note(`==> ${COMMAND}: Missing ${colors.cyan('CHANGELOG.md')} or ${colors.cyan('README.md')} in ${pluginDevDirFullPath}`)

--- a/scripts/rollup.js
+++ b/scripts/rollup.js
@@ -167,7 +167,6 @@ const dt = () => {
 
       await writeMinifiedPluginFileContents(pluginJson, path.join(targetFolder, 'plugin.json'))
       // await fs.copyFile(pluginJson, path.join(targetFolder, 'plugin.json')) //the non-minified version
-      // $FlowFixMe
       const pluginJsonData = JSON.parse(await fs.readFile(pluginJson))
 
       const pluginFolder = pluginDevFolder.replace(rootFolderPath, '').substring(1)
@@ -240,7 +239,6 @@ const dt = () => {
         message('success', msg, 'SUCCESS', true)
       }
     } else {
-      // $FlowIgnore
       console.log(`Generated "${outputFile.replace(rootFolder, '')}"`)
     }
   }
@@ -287,16 +285,13 @@ const dt = () => {
     const rootLevelFolders = rootFolder
       .filter(
         (dirent) =>
-          // $FlowIgnore
           dirent.isDirectory() && !dirent.name.startsWith('.') && !FOLDERS_TO_IGNORE.includes(dirent.name) && (limitToFolders.length === 0 || limitToFolders.includes(dirent.name)),
       )
       .map(async (dirent) => {
-        // $FlowIgnore
         const pluginFolder = path.join(__dirname, '..', dirent.name)
         const pluginContents = await fs.readdir(pluginFolder, {
           withFileTypes: true,
         })
-        // $FlowIgnore
         const isBundled = pluginContents.some((dirent) => dirent.name === 'src' && dirent.isDirectory)
         if (!isBundled) {
           return null
@@ -367,22 +362,16 @@ const dt = () => {
       const rootLevelFolders = rootFolder
         .filter(
           (dirent) =>
-            // $FlowIgnore
             dirent.isDirectory() &&
-            // $FlowIgnore
             !dirent.name.startsWith('.') &&
-            // $FlowIgnore
             !FOLDERS_TO_IGNORE.includes(dirent.name) &&
-            // $FlowIgnore
             (limitToFolders.length === 0 || limitToFolders.includes(dirent.name)),
         )
         .map(async (dirent) => {
-          // $FlowIgnore
           const pluginFolder = path.join(__dirname, '..', dirent.name)
           const pluginContents = await fs.readdir(pluginFolder, {
             withFileTypes: true,
           })
-          // $FlowIgnore
           const isBundled = pluginContents.some((dirent) => dirent.name === 'src' && dirent.isDirectory)
           if (!isBundled) {
             return null
@@ -414,7 +403,6 @@ const dt = () => {
       let cachedBundle = null
       for (const plugin of bundledPlugins) {
         const pluginJsonFilename = path.join(plugin, 'plugin.json')
-        // $FlowIgnore
         const pluginJsonData = JSON.parse(await fs.readFile(pluginJsonFilename))
 
         progress?.tick({ id: pluginJsonData['plugin.id'], mem: reportMemoryUsage('') })
@@ -492,7 +480,6 @@ const dt = () => {
           const files = await fg(path.join(requiredFilesInDevFolder, '**/*'))
           for (const file of files) {
             // console.log(`Watching ${file}`)
-            // $FlowFixMe - this works but Flow doesn't like "this" inside a function
             this.addWatchFile(file)
           }
         },

--- a/src/utils/general.js
+++ b/src/utils/general.js
@@ -28,7 +28,6 @@ module.exports = {
     const response = await fetch(URL)
 
     if (response != null) {
-      //$FlowIgnore[incompatible-call]
       const data = JSON.parse(response)[0]
       const quoteLine = `${data.q} - *${data.a}*`
       console.log(`\t${quoteLine}`)


### PR DESCRIPTION
Follow-up to #767 — **based on `flow-cleanup`, not `main`**, so review that one first. The diff here is 233 deleted comment lines and nothing else.

## What this removes

The repo carries **647** standalone `$FlowIgnore` / `$FlowFixMe` comments. **233 of them (36%) suppress nothing.** They're stale: the error they were written for got fixed later, or the comment drifted off the line it was covering. Thirteen of them sit in `scripts/rollup.js`, which has no `// @flow` pragma at all — so they never did anything.

| | |
|---|---|
| Files touched | 100 |
| Lines deleted | 233 (all comments) |
| Emitted JavaScript changed | **0 of 100 files** |
| Plugin bundles changed | 0 (`jgclark.Dashboard`, `np.Templating`, `dwertheimer.EventAutomations` rebuild identical) |
| `flow check` | 6 before → **6 after** |
| Jest | 4,621 passing, unchanged |

```
 49  np.Templating              15  dwertheimer.Forms       6  jgclark.Reviews
 46  jgclark.Dashboard          14  np.Shared               4  dwertheimer.TaskSorting
 36  helpers                     9  dwertheimer.Favorites   3  jgclark.MOCs
 16  dwertheimer.EventAutomations  6  dwertheimer.DateAutomations   3  np.Tidy
 16  scripts                                                       …and a tail
```

## How the list was produced

Worth reading, because the obvious method gives the wrong answer.

Parsing `flow check --include-suppressed` output *looks* like it identifies the dead suppressions — it reports which comment locations Flow used. Deleting the ones it didn't list took Flow from **6 errors to 38**. The attribution doesn't map cleanly onto comment lines, so that approach has false positives.

What actually works:

1. Replace **every** suppression comment with a same-length placeholder, so no line numbers shift.
2. Run `flow check` — 3,651 errors surface.
3. Restore only the placeholders that have an error on the line they cover — **414** of them.
4. Re-run — back to exactly **6** errors.

Anything still neutralised after step 3 is provably carrying no load. That's the 233 deleted here, and step 4 is the proof.

## Why it's safe to merge on sight

- Comment-only: `scripts/flow-emit-audit.js` confirms all 100 files emit byte-identical JavaScript.
- The `Flow-Check` CI ratchet from #767 will catch any regression, since it fails when a plugin's error count *rises*.
- If a suppression turns out to have been load-bearing after all, the symptom is a new Flow error in that file, not a runtime change.

## Not included

`$FlowIgnore`/`$FlowFixMe` comments that are **inline** or embedded in JSDoc prose (~130 lines) were left alone — deleting those would mean editing surrounding text rather than dropping a whole line. Only standalone comment lines are touched here.

The 414 that remain are load-bearing and stay. Reducing *those* means fixing the underlying types, which is a different piece of work.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
