### PR TITLE
Add llc.NextcloudCalendars to community plugins

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -82,5 +82,12 @@
     "author": "EduardMe",
     "description": "Import Apple Reminders into the current note as linked tasks with reminder pills that sync two-way (requires NotePlan 3.21.2+)",
     "repo": "EduardMe/noteplan-reminder-import-plugin"
+  },
+  {
+    "id": "llc.NextcloudCalendars",
+    "name": "Agendas Nextcloud",
+    "author": "Laurent Lassalle-Carrère",
+    "description": "Fetches shared CalDAV calendars from a Nextcloud server and writes a daily agenda block into your calendar notes",
+    "repo": "Bono2007/noteplan-nextcloud-calendars"
   }
 ]


### PR DESCRIPTION
Adds **Agendas Nextcloud** (`llc.NextcloudCalendars`) to `community-plugins.json`.

The plugin fetches shared CalDAV calendars from a Nextcloud server and writes a daily agenda block into calendar notes, several days ahead. It was built to follow colleagues' shared calendars, but works with any CalDAV server exposing a Nextcloud-style layout.

**Repository:** https://github.com/Bono2007/noteplan-nextcloud-calendars
**Release:** `llc-nextcloudcalendars-v1.0.0`

### What it does

- Discovers the calendars available on the server and lets the user pick which ones to follow, with short auto-derived labels
- Writes an agenda block into each of the next N daily notes (7 by default), replacing it in place on every run without touching the rest of the note
- Expands recurring events server-side via `<C:expand>`, so a weekly meeting shows up on each occurrence
- Shows multi-day events on every day they span, and all-day events without a time
- Can be called from a template, returning the block without writing anything

### Notes

- No npm dependencies. Sources in `src/` are concatenated into a single standalone `index.js` by `build.mjs`.
- 117 tests run with `node --test`, including fixtures captured from a real server response.
- The plugin does not use the repository toolchain (Flow, Rollup, noteplan-cli), which is why it lives in its own repository and is referenced here rather than vendored in.

This PR only adds one entry to `community-plugins.json`.