### PR TITLE
np.Preview: fix the last Flow error in the repo

### DIFF
--- a/np.Preview/src/previewMain.js
+++ b/np.Preview/src/previewMain.js
@@ -59,8 +59,9 @@ function resolveNoteAndContent(noteSpec?: string | TNote | null): PreviewNoteAnd
   }
 
   // Prefer open Editor buffer when it is the same file (unsaved edits)
-  if (Editor.note?.filename === note.filename && Editor.content != null) {
-    return { note: Editor.note, content: Editor.content }
+  const editorNote = Editor.note
+  if (editorNote && editorNote.filename === note.filename && Editor.content != null) {
+    return { note: editorNote, content: Editor.content }
   }
 
   const content = note.content


### PR DESCRIPTION
Fixes the one remaining `npx flow check` error in the repo.

### The error

```
Error --------------------------- np.Preview/src/previewMain.js:63:20
Cannot return object literal because null or undefined [1] is incompatible
with `Note` [2] in property `note`. [incompatible-return]
```

`Editor.note` is typed `?TNote` (`flow-typed/Noteplan.js:49`), and optional chaining inside the `if` condition does not refine it for the branch body. Hoisting to a local gives Flow a refinement it can carry through.

**No behaviour change** — when `Editor.note` is null, the old `undefined === note.filename` comparison was already false, so the branch never executed in that case anyway.

### Why CI didn't catch it

It arrived in de205fd0 (np.Preview v0.5). CI runs `scripts/flow-report.js --check`, a per-plugin *ratchet* rather than a gate — it only fails when a plugin's error-site count goes **up**. That commit removed one np.Preview error site and added this one, so the count read `-1` and stayed green. A new error slipped in under cover of an old one being fixed.

### Why now

This was the last error in the repo, so `npx flow check` is now at **0 errors**. That unblocks #772, which replaces the ratchet with a strict check — merging #772 before this fix would have turned main red immediately (`mergeStateStatus: CLEAN` doesn't help; the conflict is semantic, not textual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)